### PR TITLE
Add Trio ADT example and tests

### DIFF
--- a/docs/genia.md
+++ b/docs/genia.md
@@ -106,6 +106,24 @@ print(square(4))
 
 ---
 
+### Algebraic Data Types
+GENIA supports simple tagged unions using the `data` keyword. Constructors are
+regular functions that build structured values which can be decomposed through
+pattern matching.
+
+Example:
+```genia
+data Trio = Trio(a, b, c)
+
+fn first(Trio(x, _, _)) -> x
+first(Trio(1, 2, 3))
+```
+
+The call above evaluates to `1` as the `first` function matches the `Trio`
+constructor and extracts its first field.
+
+---
+
 ### Command-Line Arguments
 Command-line arguments are accessed via `$1`, `$2`, ... `$NF` for the total count.
 

--- a/tests/test_adt.py
+++ b/tests/test_adt.py
@@ -34,3 +34,23 @@ def test_adt_pattern_match_none():
     interp = GENIAInterpreter()
     assert interp.run(code) == 0
 
+
+def test_trio_constructor():
+    code = """
+    data Trio = Trio(a, b, c)
+    Trio(1, 2, 3)
+    """
+    interp = GENIAInterpreter()
+    result = interp.run(code)
+    assert result == {'type': 'Trio', 'ctor': 'Trio', 'values': [1, 2, 3]}
+
+
+def test_trio_pattern_match():
+    code = """
+    data Trio = Trio(a, b, c)
+    fn sum_trio(Trio(x, y, z)) -> x + y + z
+    sum_trio(Trio(1, 2, 3))
+    """
+    interp = GENIAInterpreter()
+    assert interp.run(code) == 6
+


### PR DESCRIPTION
## Summary
- document algebraic data types with a Trio example
- test construction and pattern matching for Trio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596e5ad50c8329a4907db2ef3ccaf0