### PR TITLE
Fix negative range parsing

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -353,6 +353,11 @@ def test_interpreter_range_same(interpreter_fixture):
     code = "10..10"
     result = interpreter_fixture.run(code)
     assert list(result) == [10]
+
+def test_interpreter_negative_range(interpreter_fixture):
+    code = "-3..3"
+    result = interpreter_fixture.run(code)
+    assert list(result) == [-3, -2, -1, 0, 1, 2, 3]
     
 def test_interpreter_pattern_match_empty_list(interpreter_fixture):
     code = """

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -267,6 +267,18 @@ def test_range():
     ]
     assert tokens == expected
 
+def test_negative_range_tokens():
+    code = "-10..10"
+    tokens = tokenize(code)
+
+    expected = [
+        ('OPERATOR', '-', 1, 1),
+        ('NUMBER', '10', 1, 2),
+        ('OPERATOR', '..', 1, 4),
+        ('NUMBER', '10', 1, 6),
+    ]
+    assert tokens == expected
+
 def test_end_of_list():
     code = "[first, ..rest, last]"
     tokens = tokenize(code)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -292,6 +292,22 @@ def test_range():
     ]
     assert result == expected
 
+def test_negative_range():
+    code = "-10..10"
+    result = parse(code)
+    expected = [{
+        'type': 'expression_statement',
+        'expression': {
+            'type': 'operator', 'operator': '..',
+            'left': {
+                'type': 'unary_operator', 'operator': '-',
+                'operand': {'type': 'number', 'value': '10'}
+            },
+            'right': {'type': 'number', 'value': '10'}
+        }
+    }]
+    assert strip_metadata(result) == strip_metadata(expected)
+
 
 def test_list_destructuring():
     code = "[first, ..rest]"


### PR DESCRIPTION
## Summary
- parse unary '+' and '-' with higher precedence so negative ranges like `-3..3` parse correctly
- keep spread `..` operator behavior for list splicing
- add lexer test for negative ranges
- add parser test for negative ranges
- add interpreter test for negative ranges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7758fa5483298017d1623405af03