### PR TITLE
Fix tail recursion for seq.genia

### DIFF
--- a/scripts/seq.genia
+++ b/scripts/seq.genia
@@ -39,33 +39,36 @@ fn interpose(_, [h])            -> [h]
 fn interpose(item, [hf, ..r])   -> reduce(fn(acc, el) -> [..acc, item, el], [hf], r)
 
 fn interleve(l) -> l
-fn interleve(_, []) -> [] 
-fn interleve([], _) -> []
-fn interleve([h1, ..r1], [h2, ..r2]) -> [h1, h2, ..interleve(r1, r2)]
-fn interleve
-    (_, [], _) -> [] 
-    | ([], _, _) -> [] 
-    | (_, _, []) -> [] 
-    | ([h1, ..r1], [h2, ..r2], [h3, ..r3]) -> [h1, h2, h3, ..interleve(r1, r2, r3)]
-fn interleve
-    (_, [], _, _) -> [] 
-    | ([], _, _, _) -> [] 
-    | (_, _, [],_) -> [] 
-    | (_, _, _, []) -> [] 
-    | ([h1, ..r1], [h2, ..r2], [h3, ..r3], [h4, ..r4]) -> [h1, h2, h3, h4, ..interleve(r1, r2, r3, r4)]
+fn interleve(l1, l2) -> interleve(l1, l2, [])
+fn interleve([], _, acc) -> reverse(acc)
+    | (_, [], acc) -> reverse(acc)
+    | ([h1, ..r1], [h2, ..r2], acc) -> interleve(r1, r2, [h2, h1, ..acc])
+fn interleve(l1, l2, l3) -> interleve(l1, l2, l3, [])
+fn interleve([], _, _, acc) -> reverse(acc)
+    | (_, [], _, acc) -> reverse(acc)
+    | (_, _, [], acc) -> reverse(acc)
+    | ([h1, ..r1], [h2, ..r2], [h3, ..r3], acc) -> interleve(r1, r2, r3, [h3, h2, h1, ..acc])
+fn interleve(l1, l2, l3, l4) -> interleve(l1, l2, l3, l4, [])
+fn interleve([], _, _, _, acc) -> reverse(acc)
+    | (_, [], _, _, acc) -> reverse(acc)
+    | (_, _, [], _, acc) -> reverse(acc)
+    | (_, _, _, [], acc) -> reverse(acc)
+    | ([h1, ..r1], [h2, ..r2], [h3, ..r3], [h4, ..r4], acc) -> interleve(r1, r2, r3, r4, [h4, h3, h2, h1, ..acc])
 
 fn distinct() -> []
 fn distinct([]) -> []
-fn distinct(list) -> distinct([], list)
-fn distinct(seen, []) -> seen
-fn distinct(seen, [head, ..tail]) when any?(equal?(head), seen) -> distinct(seen, tail)
-fn distinct(seen, [head, ..tail]) -> [head, ..distinct([head, ..seen], tail)]
+fn distinct(list) -> distinct(list, [])
+fn distinct([], acc) -> reverse(acc)
+fn distinct([head, ..tail], acc) when any?(equal?(head), acc) -> distinct(tail, acc)
+fn distinct([head, ..tail], acc) -> distinct(tail, [head, ..acc])
 
 fn nequal?(v) -> fn(y) -> v != y
 
 fn distinct2() -> []
 fn distinct2([]) -> []
-fn distinct2([head, ..tail]) -> [head, ..distinct2(filter(nequal?(head), tail))]
+fn distinct2(list) -> distinct2(list, [])
+fn distinct2([], acc) -> reverse(acc)
+    | ([head, ..tail], acc) -> distinct2(filter(nequal?(head), tail), [head, ..acc])
 
 
 fn inc(i) -> i + 1

--- a/tests/test_seq_functions.py
+++ b/tests/test_seq_functions.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from genia.interpreter import GENIAInterpreter
+
+# Load base functions directly from scripts/seq.genia up to the utility section
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / 'scripts' / 'seq.genia'
+FILE_CONTENT = SCRIPT_PATH.read_text()
+BASE_FUNCTIONS = FILE_CONTENT.split('fn inc')[0]
+# Provide missing helper used by distinct
+BASE_FUNCTIONS += "\nfn equal?(x) -> fn(y) -> x == y | (x, y) -> x == y"
+
+def run(code: str):
+    interp = GENIAInterpreter()
+    return interp.run(BASE_FUNCTIONS + '\n' + code)
+
+def test_distinct_small():
+    code = 'distinct([1,1,2,3,2,3])'
+    assert run(code) == [1,2,3]
+
+def test_distinct_large():
+    n = 2000
+    code = f'distinct(1..{n})'
+    result = run(code)
+    assert result == list(range(1, n+1))
+
+def test_distinct2_small():
+    code = 'distinct2([1,1,2,2,3,3,2])'
+    assert run(code) == [1,2,3]
+
+def test_interleve_two_lists():
+    code = 'interleve([1,2,3], [4,5,6])'
+    assert run(code) == [1,4,2,5,3,6]
+
+def test_interleve_large():
+    n = 1000
+    code = f'interleve(1..{n}, {n+1}..{2*n})'
+    result = run(code)
+    expected = []
+    for a, b in zip(range(1, n+1), range(n+1, 2*n+1)):
+        expected.extend([a, b])
+    assert result == expected


### PR DESCRIPTION
## Summary
- optimize `distinct`, `distinct2`, and `interleve` in `seq.genia` to use tail-recursion
- add tests covering these optimized functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b827dc260832991a035c092e1808b