### PR TITLE
Fix multi-guard functions

### DIFF
--- a/genia/parser.py
+++ b/genia/parser.py
@@ -169,6 +169,12 @@ class Parser:
                         else:
                             raise self.SyntaxError(f"Expected ',' or ')' after parameter at line {line}, column {column}")
 
+                # Check for 'when' guard on alternative definition
+                guard = None
+                if self.tokens and self.tokens[0][0] == 'KEYWORD' and self.tokens[0][1] == 'when':
+                    self.tokens.popleft()  # consume 'when'
+                    guard = self.expression()
+
                 # Expect '->'
                 if not self.tokens:
                     raise self.SyntaxError("Unexpected end of input after alternative parameters")
@@ -181,7 +187,7 @@ class Parser:
 
                 definitions.append({
                     'parameters': parameters,
-                    'guard': None,  # Guards are only allowed in the first definition
+                    'guard': guard,
                     'body': body.get('value') if body.get('type') == 'foreign' else body,
                     'foreign': body.get('type') == 'foreign',
                 })

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -185,6 +185,18 @@ def test_interpreter_function_with_guard(interpreter_fixture):
     result = interpreter_fixture.run(code)
     assert 30 == result
 
+
+def test_interpreter_multiple_guards(interpreter_fixture):
+    code = """
+    fn foo(x) when x > 10 -> x * 2
+        | (x) when x < 5 -> x + 2;
+
+    foo(3);
+    foo(15);
+    """
+    result = interpreter_fixture.run(code)
+    assert 30 == result
+
 def test_interpreter_cons_list_reduce(interpreter_fixture):
     code = """
     trace()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -246,6 +246,55 @@ def test_function_with_guard():
     assert strip_metadata(ast) == strip_metadata(expected_ast)
 
 
+def test_multi_arity_with_guards():
+    code = """fn foo(x) when x > 10 -> x
+| (x) when x < 5 -> x + 1
+"""
+    lexer = Lexer(code)
+    tokens = lexer.tokenize()
+
+    parser = Parser(tokens)
+    ast = parser.parse()
+
+    expected_ast = [
+        {
+            "type": "function_definition",
+            "name": "foo",
+            "definitions": [
+                {
+                    "parameters": [{"type": "identifier", "value": "x"}],
+                    "guard": {
+                        "type": "comparator",
+                        "operator": ">",
+                        "left": {"type": "identifier", "value": "x"},
+                        "right": {"type": "number", "value": "10"}
+                    },
+                    "body": {"type": "identifier", "value": "x"},
+                    "foreign": False
+                },
+                {
+                    "parameters": [{"type": "identifier", "value": "x"}],
+                    "guard": {
+                        "type": "comparator",
+                        "operator": "<",
+                        "left": {"type": "identifier", "value": "x"},
+                        "right": {"type": "number", "value": "5"}
+                    },
+                    "body": {
+                        "type": "operator",
+                        "operator": "+",
+                        "left": {"type": "identifier", "value": "x"},
+                        "right": {"type": "number", "value": "1"}
+                    },
+                    "foreign": False
+                },
+            ]
+        }
+    ]
+
+    assert strip_metadata(ast) == strip_metadata(expected_ast)
+
+
 def test_ffi_simple():
     code = 'fn rem(x,y) -> foreign "math.remainder"'
     lexer = Lexer(code)


### PR DESCRIPTION
## Summary
- support guards on every function definition
- test parsing and interpreting multi-guard functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c25e7f7a883298034f3c2169af1e4