### PR TITLE
Add project goals documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 GENIA is a concise and dynamic scripting language designed for data processing and automation tasks. It offers dual execution modes, context-aware variables, and intuitive syntax, making it accessible for both novice and experienced programmers.
 
+See [docs/goals.md](docs/goals.md) for the project goals.
+
 ## Features
 
 - **Dual Execution Modes**: Supports Default and AWK-like modes for versatile input processing.

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,0 +1,15 @@
+# Project Goals
+
+This document highlights the guiding principles behind GENIA's design.
+
+## Ease of Learning
+
+GENIA aims to be approachable for users with little to no programming experience. The syntax favors clear, minimal constructs so that new users can start writing useful scripts quickly.
+
+## AI Integration
+
+The language is designed with both external AI assistance and internal AI features in mind. Its structures are intended to be straightforward for an AI partner to reason about while still remaining easy for humans to read and modify.
+
+## Bootstrappable Core
+
+Only a small core language is implemented in the interpreter itself. Higher-level features are planned to be built as macros so that GENIA can grow organically from a minimal base.


### PR DESCRIPTION
## Summary
- add project goals covering ease of learning, AI integration, and a bootstrappable core
- link to the goals document from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878030a26b08329b2f7455f75b80426