### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/future.md
+++ b/docs/future.md
@@ -12,5 +12,5 @@
 
 # Near future
 - Truthyness
-- A way to create a variable simialar to Clojure delay but built-in so it doesn't have to be deref
+- A way to create a variable similar to Clojure delay but built-in so it doesn't have to be deref
 - Pipelines


### PR DESCRIPTION
## Summary
- fix a typo in `future.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687802e7d8b08329a30b7559c2651204