### PR TITLE
Replace fn and data keywords with define

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ python -m genia_interpreter script.genia 1 2 3
 #### AWK Mode Example
 
 ```genia
-fn before() {
+define before() {
     lineCount = 0;
 }
 
 lineCount = lineCount + 1;
 
-fn after() {
+define after() {
     print("Total lines: " + lineCount);
 }
 ```

--- a/docs/genia.md
+++ b/docs/genia.md
@@ -52,20 +52,20 @@ Functions can be defined natively or as foreign functions.
 
 Example:
 ```genia
-fn add(x, y) -> x + y
-fn foreign_rem(x, y) -> foreign "math.remainder"
+define add(x, y) -> x + y
+define foreign_rem(x, y) -> foreign "math.remainder"
 ```
 
 #### Multi-body Functions
 Functions support multiple bodies and guards:
 ```genia
-fn fact(0) -> 1 | fact(n) -> n * fact(n - 1)
+define fact(0) -> 1 | fact(n) -> n * fact(n - 1)
 ```
 
 #### Optional Syntax
 Parentheses and commas are optional in definitions:
 ```genia
-fn greet name -> "Hello, " + name
+define greet name -> "Hello, " + name
 ```
 
 ---
@@ -97,7 +97,7 @@ Modules enable organized code and reusable namespaces.
 Example:
 ```genia
 // math.genia
-export fn square(x) -> x * x
+export define square(x) -> x * x
 
 // main.genia
 import { square } from "math"
@@ -107,15 +107,15 @@ print(square(4))
 ---
 
 ### Algebraic Data Types
-GENIA supports simple tagged unions using the `data` keyword. Constructors are
+GENIA supports simple tagged unions using the `define` keyword. Constructors are
 regular functions that build structured values which can be decomposed through
 pattern matching.
 
 Example:
 ```genia
-data Trio = Trio(a, b, c)
+define Trio = Trio(a, b, c)
 
-fn first(Trio(x, _, _)) -> x
+define first(Trio(x, _, _)) -> x
 first(Trio(1, 2, 3))
 ```
 
@@ -141,7 +141,7 @@ decide after() { print("Processed " + lineCount + " lines.") }
 ### Error Handling
 Supports Erlang-style restarts:
 ```genia
-retry(fn, max_attempts=3, backoff=exponential)
+retry(define, max_attempts=3, backoff=exponential)
 ```
 
 ---
@@ -151,7 +151,7 @@ retry(fn, max_attempts=3, backoff=exponential)
 ### Lexer
 - Supports Unicode and special characters like `*` and `?`.
 - Tokens:
-  - Keywords: `fn`, `foreign`, `when`
+  - Keywords: `define`, `foreign`, `when`
   - Operators: `+`, `-`, `*`, `/`, `=`, etc.
   - Punctuation: `(`, `)`, `{`, `}`, `,`, `;`
 
@@ -167,7 +167,7 @@ retry(fn, max_attempts=3, backoff=exponential)
 - Links GENIA functions to external Python functions.
 - Example:
 ```genia
-fn foreign_rem(x, y) -> foreign "math.remainder"
+define foreign_rem(x, y) -> foreign "math.remainder"
 ```
 
 ---

--- a/docs/lexer.md
+++ b/docs/lexer.md
@@ -76,7 +76,7 @@ Reserved words that have special meaning in GENIA's syntax and cannot be used as
 
 **List of Keywords:**
 
-- `fn`
+- `define`
 - `delay`
 - `foreign`
 
@@ -365,7 +365,7 @@ Below is a summary of all token patterns used by the GENIA Lexer:
 | **PUNCTUATION**          | `[()\[\]{},;]`                                                                                      | Parentheses, brackets, braces, commas, semicolons         |
 | **NUMBER**               | `\d+`                                                                                                | Integer numbers                                          |
 | **IDENTIFIER**           | `\$?[\w*+\-/?]+`                                                                                     | Identifiers with optional `$` and special characters      |
-| **KEYWORD**              | `\bfn\b|\bdelay\b|\bforeign\b`                                                                       | Reserved keywords                                        |
+| **KEYWORD**              | `\bdefine\b|\bdelay\b|\bforeign\b`                                                                       | Reserved keywords                                        |
 | **MISMATCH**             | `.`                                                                                                  | Any other character; triggers a syntax error             |
 
 ---
@@ -460,12 +460,12 @@ Accurate tracking of line and column numbers is vital for:
 Given the code:
 
 ```genia
-fn add(a, b) ->
+define add(a, b) ->
   a + b;
 ```
 
-- **First Line (`fn add(a, b) ->`):**
-  - `fn` at line `1`, column `1`.
+- **First Line (`define add(a, b) ->`):**
+  - `define` at line `1`, column `1`.
   - `add` at line `1`, column `4`.
   
 - **Second Line (`  a + b;`):**
@@ -490,10 +490,10 @@ Proper error handling ensures that the lexer can gracefully handle unexpected or
 Given the code:
 
 ```genia
-fn invalid @
+define invalid @
 ```
 
-- The lexer recognizes `fn` and `invalid` as valid tokens.
+- The lexer recognizes `define` and `invalid` as valid tokens.
 - The `@` character does not match any token patterns, resulting in a `SyntaxError`:
 
 ```
@@ -575,14 +575,14 @@ r"[A-Z]+\n" "regular\nstring"
 **Code:**
 
 ```genia
-fn foo() -> 0 | (_) -> 1
+define foo() -> 0 | (_) -> 1
 ```
 
 **Tokenization:**
 
 | Token Type     | Value   | Line | Column |
 |----------------|---------|------|--------|
-| KEYWORD        | `fn`    | 1    | 1      |
+| KEYWORD        | `define`    | 1    | 1      |
 | IDENTIFIER     | `foo`   | 1    | 4      |
 | PUNCTUATION    | `(`     | 1    | 7      |
 | PUNCTUATION    | `)`     | 1    | 8      |
@@ -598,8 +598,8 @@ fn foo() -> 0 | (_) -> 1
 
 **Explanation:**
 
-- **Function Definition (`fn foo() -> 0`):**
-  - `fn` is a keyword.
+- **Function Definition (`define foo() -> 0`):**
+  - `define` is a keyword.
   - `foo` is an identifier.
   - `()` denotes an empty parameter list.
   - `->` represents the arrow operator.
@@ -700,7 +700,7 @@ class Lexer:
                 continue
             elif kind in ('WHITESPACE', 'COMMENT'):
                 continue
-            elif kind == 'IDENTIFIER' and value in ['fn', 'delay', 'foreign']:
+            elif kind == 'IDENTIFIER' and value in ['define', 'delay', 'foreign']:
                 kind = 'KEYWORD'
             elif kind == 'MISMATCH':
                 raise self.SyntaxError(f"Unexpected character '{value}' at line {line_num}, column {column}")
@@ -755,7 +755,7 @@ Below is the comprehensive list of tokens recognized by the GENIA Lexer, along w
 | **PUNCTUATION**| `[()\[\]{},;]`                                                                                      | Parentheses, brackets, braces, commas, semicolons         |
 | **NUMBER**     | `\d+`                                                                                                | Integer numbers                                          |
 | **IDENTIFIER** | `\$?[\w*+\-/?]+`                                                                                     | Identifiers with optional `$` and special characters      |
-| **KEYWORD**    | `\bfn\b|\bdelay\b|\bforeign\b`                                                                       | Reserved keywords                                        |
+| **KEYWORD**    | `\bdefine\b|\bdelay\b|\bforeign\b`                                                                       | Reserved keywords                                        |
 | **MISMATCH**   | `.`                                                                                                  | Any other character; triggers a syntax error             |
 
 ### **6.2. Regex Patterns**
@@ -903,11 +903,11 @@ r"([^"\\]|\\.)*?" | r'([^\'\\]|\\.)*?'
 #### **6.2.14. KEYWORD**
 
 ```regex
-\bfn\b|\bdelay\b|\bforeign\b
+\bdefine\b|\bdelay\b|\bforeign\b
 ```
 
 - **Explanation:**
-  - Matches exact words `fn`, `delay`, or `foreign` using word boundaries (`\b`).
+  - Matches exact words `define`, `delay`, or `foreign` using word boundaries (`\b`).
 
 #### **6.2.15. MISMATCH**
 

--- a/docs/lists.md
+++ b/docs/lists.md
@@ -219,7 +219,7 @@ Environment after evaluation:
 
 1. **Pattern Matching in Function Parameters**:
    ```genia
-   fn sum([first, ..rest]) -> first + sum(rest) | [] -> 0
+   define sum([first, ..rest]) -> first + sum(rest) | [] -> 0
    ```
 
 2. **Destructuring with Defaults**:

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -67,7 +67,7 @@ Before delving into the syntax, it's essential to understand the lexical element
 
 The GENIA lexer identifies the following token types:
 
-- **Keywords**: `fn`, `delay`, `foreign`
+- **Keywords**: `define`, `delay`, `foreign`
 - **Identifiers**: Names for variables, functions, etc. (e.g., `foo`, `x`, `calculate`)
 - **Operators**: `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `and`, `or`, `not`
 - **Punctuations**: `(`, `)`, `[`, `]`, `,`, `;`, `=`, `->`, `|`, `...`
@@ -96,24 +96,24 @@ This section details the grammatical rules of the GENIA language, defining how v
 
 ### Function Definitions
 
-GENIA allows defining functions using the `fn` keyword. Functions can have multiple definitions (overloading) differentiated by parameter patterns and guards.
+GENIA allows defining functions using the `define` keyword. Functions can have multiple definitions (overloading) differentiated by parameter patterns and guards.
 
 #### Basic Function Definition
 
 ```genia
-fn functionName(parameters) -> expression;
+define functionName(parameters) -> expression;
 ```
 
 **Example:**
 
 ```genia
-fn add(x, y) -> x + y;
+define add(x, y) -> x + y;
 ```
 
 #### Function Definition with Multiple Arity and Guards
 
 ```genia
-fn functionName(parameters) when condition -> expression;
+define functionName(parameters) when condition -> expression;
 | (alternativeParameters) when alternativeCondition -> alternativeExpression;
 | (otherParameters) -> otherExpression;
 ```
@@ -121,7 +121,7 @@ fn functionName(parameters) when condition -> expression;
 **Example:**
 
 ```genia
-fn process(x) when x > 0 -> x;
+define process(x) when x > 0 -> x;
 | (x) when x < 0 -> -x;
 ```
 
@@ -201,13 +201,13 @@ GENIA supports comprehensive pattern matching in function parameters, including 
 #### List Patterns
 
 ```genia
-fn functionName([pattern1, pattern2, ..spreadPattern]) -> expression;
+define functionName([pattern1, pattern2, ..spreadPattern]) -> expression;
 ```
 
 **Example:**
 
 ```genia
-fn unpack([a, ..rest]) -> a;
+define unpack([a, ..rest]) -> a;
 ```
 
 #### Wildcard Patterns
@@ -217,7 +217,7 @@ The `_` identifier can be used as a wildcard to ignore specific elements in patt
 **Example:**
 
 ```genia
-fn ignore_second([a, _, c]) -> a + c;
+define ignore_second([a, _, c]) -> a + c;
 ```
 
 **Notes:**
@@ -237,7 +237,7 @@ GENIA allows the creation and manipulation of list data structures using square 
 **Example:**
 
 ```genia
-fn create_list() -> [1, 2, 3, ..additional];
+define create_list() -> [1, 2, 3, ..additional];
 ```
 
 **Notes:**
@@ -251,13 +251,13 @@ GENIA can integrate with external (foreign) functions seamlessly, allowing calls
 #### Foreign Function Syntax
 
 ```genia
-foreign "module.functionName" -> fn(parameters) -> expression;
+foreign "module.functionName" -> define(parameters) -> expression;
 ```
 
 **Example:**
 
 ```genia
-foreign "math.sqrt" -> fn(x) -> sqrt(x);
+foreign "math.sqrt" -> define(x) -> sqrt(x);
 ```
 
 **Notes:**
@@ -278,7 +278,7 @@ delay(expression);
 **Example:**
 
 ```genia
-fn compute() -> delay(fn(x) -> x * x);
+define compute() -> delay(define(x) -> x * x);
 ```
 
 **Notes:**
@@ -868,7 +868,7 @@ Below are several examples illustrating how GENIA code snippets are parsed into 
 **GENIA Code:**
 
 ```genia
-fn unpack([a, ..rest]) -> a;
+define unpack([a, ..rest]) -> a;
 ```
 
 **AST:**
@@ -911,7 +911,7 @@ fn unpack([a, ..rest]) -> a;
 **GENIA Code:**
 
 ```genia
-fn outer() -> (fn inner() -> 42; inner());
+define outer() -> (define inner() -> 42; inner());
 ```
 
 **AST:**
@@ -973,7 +973,7 @@ fn outer() -> (fn inner() -> 42; inner());
 **GENIA Code:**
 
 ```genia
-fn factorial(n) when n > 1 -> n * factorial(n - 1) | (n) -> 1;
+define factorial(n) when n > 1 -> n * factorial(n - 1) | (n) -> 1;
 ```
 
 **AST:**
@@ -1047,7 +1047,7 @@ fn factorial(n) when n > 1 -> n * factorial(n - 1) | (n) -> 1;
 **GENIA Code:**
 
 ```genia
-fn combine_lists(list1, list2) -> merge(...list1, ...list2);
+define combine_lists(list1, list2) -> merge(...list1, ...list2);
 ```
 
 **AST:**
@@ -1146,7 +1146,7 @@ Below is an example of how to implement a unit test for nested function definiti
 
 def test_parser_nested_function_definitions():
     code = """
-    fn outer() -> (fn inner() -> 42; inner());
+    define outer() -> (define inner() -> 42; inner());
     """
     ast = parse(code)
     

--- a/docs/regex.md
+++ b/docs/regex.md
@@ -173,7 +173,7 @@ Guards in Genia allow conditions to refine the applicability of a function defin
 ### **Syntax**
 
 ```genia
-fn function_name(param) when param ~ pattern -> result
+define function_name(param) when param ~ pattern -> result
 ```
 
 - **`when param ~ pattern`**: The function definition is selected only if `param` matches the regex pattern.
@@ -183,7 +183,7 @@ fn function_name(param) when param ~ pattern -> result
 #### **Guard with Regex Matching**
 
 ```genia
-fn validate(input) when input ~ r"^\d{3}-\d{3}-\d{4}$" -> true
+define validate(input) when input ~ r"^\d{3}-\d{3}-\d{4}$" -> true
          | (_) -> false;
 
 result = validate("123-456-7890")
@@ -193,7 +193,7 @@ result = validate("123-456-7890")
 #### **Multiple Guards**
 
 ```genia
-fn classify(input) when input ~ r"^\d+$" -> "All digits"
+define classify(input) when input ~ r"^\d+$" -> "All digits"
          | (input) when input ~ r"^[A-Za-z]+$" -> "All letters"
          | (_) -> "Mixed content"
 
@@ -214,14 +214,14 @@ result3 = classify("Hello123")
 1. **Invalid Regex Pattern in Guard**:
    - Throws a `RuntimeError` with a clear error message.
    ```genia
-   fn example(input) when input ~ "[A-Z" -> true
+   define example(input) when input ~ "[A-Z" -> true
    // RuntimeError: Invalid regex pattern "[A-Z"
    ```
 
 2. **Non-String Parameter**:
    - Throws a `RuntimeError` if the guarded parameter is not a string.
    ```genia
-   fn example(input) when input ~ r"^\d+$" -> true
+   define example(input) when input ~ r"^\d+$" -> true
    result = example(123)
    // RuntimeError: Regex match requires the parameter to be a string
    ```
@@ -233,7 +233,7 @@ result3 = classify("Hello123")
 ### **Regex Guards in Functions**
 
 ```genia
-fn format_date(input) when input ~ r"^\d{4}-\d{2}-\d{2}$" -> "Valid date format"
+define format_date(input) when input ~ r"^\d{4}-\d{2}-\d{2}$" -> "Valid date format"
             | (_) -> "Invalid date format";
 
 result1 = format_date("2025-01-15")
@@ -272,7 +272,7 @@ This section describes how regex can be used in guards to enhance function defin
 ## **Example Script**
 
 ```genia
-fn validate_phone(input) -> input ~ r"^\d{3}-\d{3}-\d{4}$";
+define validate_phone(input) -> input ~ r"^\d{3}-\d{3}-\d{4}$";
 
 phone = "123-456-7890"
 is_valid = validate_phone(phone)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -59,36 +59,36 @@ name = "GENIA";
 ### Functions
 
 #### Function Definitions
-Functions are defined using the `fn` keyword. Parameters are enclosed in parentheses, and the return value follows `->`.
+Functions are defined using the `define` keyword. Parameters are enclosed in parentheses, and the return value follows `->`.
 
 ##### Native Functions
 ```genia
-fn add(x, y) -> x + y;
+define add(x, y) -> x + y;
 ```
 
 ##### Foreign Functions
 Foreign functions are defined using the `-> foreign` syntax:
 ```genia
-fn rem(x, y) -> foreign "math.remainder";
+define rem(x, y) -> foreign "math.remainder";
 ```
 
 #### Combined Functions
 Supports combining multiple functions into a single function using the `|` operator:
 ```genia
-fn compute(x, y) -> foreign "math.remainder" | (x) -> x | () -> 0
+define compute(x, y) -> foreign "math.remainder" | (x) -> x | () -> 0
 ```
 
 #### Multi-body Functions
 Functions can define multiple bodies with the `|` operator:
 ```genia
-fn fact(0) -> 1 | fact(n) -> n * fact(n - 1);
+define fact(0) -> 1 | fact(n) -> n * fact(n - 1);
 ```
 
 #### Pattern Matching
 Pattern matching is supported using constants in the arg list:
 ```genia
-fn cons(a, b) -> fn () -> 1 | (1) -> a | (2) -> b;
-fn cons() -> fn () -> 0;
+define cons(a, b) -> define () -> 1 | (1) -> a | (2) -> b;
+define cons() -> define () -> 0;
 ---
 
 ### Modules
@@ -106,7 +106,7 @@ Modules organize code into reusable namespaces.
 
 #### Examples
 ```genia
-fn example(x*, y?) -> x* + y?;
+define example(x*, y?) -> x* + y?;
 ```
 
 Lexer output:
@@ -123,7 +123,7 @@ The FFI allows GENIA to call functions from external modules, libraries, or buil
 
 #### Syntax
 ```genia
-fn rem(x, y) -> foreign "math.remainder";
+define rem(x, y) -> foreign "math.remainder";
 ```
 
 - The string `"math.remainder"` is resolved into a Python callable using dynamic import:
@@ -144,9 +144,9 @@ fn rem(x, y) -> foreign "math.remainder";
 
 #### Math Utilities
 ```genia
-fn add(x, y) -> x + y;
-fn sub(x, y) -> x - y;
-fn rem(x, y) -> foreign "math.remainder";
+define add(x, y) -> x + y;
+define sub(x, y) -> x - y;
+define rem(x, y) -> foreign "math.remainder";
 
 print(add(5, 3));  // Output: 8
 print(sub(10, 4)); // Output: 6
@@ -156,8 +156,8 @@ print(rem(7, 3));  // Output: 1.0
 #### Using Modules
 ```genia
 // File: math.genia
-export fn square(x) -> x * x;
-export fn cube(x) -> x * x * x;
+export define square(x) -> x * x;
+export define cube(x) -> x * x * x;
 export const PI = 3.14159;
 
 // Main Script

--- a/genia/interpreter.py
+++ b/genia/interpreter.py
@@ -964,7 +964,7 @@ def main():
 
     # Example GENIA code with regex matching
     code = """
-    fn foo(a) when a ~ r"[a-z]" -> 42 | (_) -> -1
+    define foo(a) when a ~ r"[a-z]" -> 42 | (_) -> -1
     foo("aa")
     """
     # Execute the code

--- a/genia/lexer.py
+++ b/genia/lexer.py
@@ -20,7 +20,7 @@ class Lexer:
         ('OPERATOR', r'\.\.|[+\-*/%=~]'),                            # +, -, *, /, %, =, ~
         ('PUNCTUATION', r'[()\[\]{},;|]'),                       # Punctuation
         ('NUMBER', r'\d+'),                                     # Integer numbers
-        ('KEYWORD', r'\bfn\b|\bdelay\b|\bforeign\b|\bwhen\b|\bdata\b'),  # Keywords
+        ('KEYWORD', r'\bdefine\b|\bdelay\b|\bforeign\b|\bwhen\b'),  # Keywords
         ('IDENTIFIER', r'\$?[\w*+\-/?]+'),                      # Identifiers with *, +, -, /, ?
         ('MISMATCH', r'.'),                                      # Any other character
     ]
@@ -48,7 +48,7 @@ class Lexer:
                 continue
             elif kind == 'WHITESPACE' or kind == 'COMMENT':
                 continue
-            elif kind == 'IDENTIFIER' and value in ['fn', 'delay', 'foreign', 'when']:
+            elif kind == 'IDENTIFIER' and value in ['define', 'delay', 'foreign', 'when']:
                 kind = 'KEYWORD'
             elif kind == 'MISMATCH':
                 raise self.SyntaxError(f"Unexpected character '{value}' at line {line_num}, column {column}")

--- a/scripts/1and7.genia
+++ b/scripts/1and7.genia
@@ -1,4 +1,4 @@
-fn body
+define body
     () when NR == 1             -> NR 
   | () when NR == 19            -> NR 
   | () when $7 ~ r"^[0-9]+$"    -> NR

--- a/scripts/apply.genia
+++ b/scripts/apply.genia
@@ -1,14 +1,14 @@
-fn apply(f, []) -> f()
-fn apply(f, [a]) -> f(a)
-fn apply(f, [a, b]) -> f(a, b)
-fn apply(f, [a, b, c]) -> f(a, b, c)
-fn apply(f, [a, b, c, d, ..r]) -> f(a, b, c, d)
+define apply(f, []) -> f()
+define apply(f, [a]) -> f(a)
+define apply(f, [a, b]) -> f(a, b)
+define apply(f, [a, b, c]) -> f(a, b, c)
+define apply(f, [a, b, c, d, ..r]) -> f(a, b, c, d)
 
-fn add(a,b,c,d) -> a + b + c + d
-fn add(a,b,c) -> a + b + c
-fn add(a,b) -> a + b
-fn add(a) -> a
-fn add() -> 0
+define add(a,b,c,d) -> a + b + c + d
+define add(a,b,c) -> a + b + c
+define add(a,b) -> a + b
+define add(a) -> a
+define add() -> 0
 
 
 print(apply(add, [1,2,3, 5]))

--- a/scripts/cons.genia
+++ b/scripts/cons.genia
@@ -1,13 +1,13 @@
-fn cons(a, b) -> fn () -> 1 | (1) -> a | (2) -> b;
-fn cons() -> fn () -> 0;
+define cons(a, b) -> define () -> 1 | (1) -> a | (2) -> b;
+define cons() -> define () -> 0;
 
-fn car(c) when c() > 0 -> c(1)
-fn car(c) -> c
+define car(c) when c() > 0 -> c(1)
+define car(c) -> c
 
-fn cdr(c_cdr) when c_cdr() > 0 -> c_cdr(2)
-fn cdr(c_cdr) -> c_cdr
+define cdr(c_cdr) when c_cdr() > 0 -> c_cdr(2)
+define cdr(c_cdr) -> c_cdr
 
-fn cdar(c_cadr) -> car(cdr(c_cadr))
+define cdar(c_cadr) -> car(cdr(c_cadr))
 
 c2 = cons(1,2)
 

--- a/scripts/csv_test.genia
+++ b/scripts/csv_test.genia
@@ -1,8 +1,8 @@
-fn begin()  -> print("Starting AWK mode")
+define begin()  -> print("Starting AWK mode")
 
-fn end()    -> print("Processed " , NR , " lines")
+define end()    -> print("Processed " , NR , " lines")
 
-fn body() when NR == 1  -> print("Skipping Header")
+define body() when NR == 1  -> print("Skipping Header")
     |  ()               -> (
                             print("Line " , NR , " has " , NF , " fields");
                             t = t + $2

--- a/scripts/delay.genia
+++ b/scripts/delay.genia
@@ -4,9 +4,9 @@ x = delay(1)
 y = 2
 print("Delayed x:", x)
 
-fn repeat(v) -> delayseq(v, delay(repeat(v)))
+define repeat(v) -> delayseq(v, delay(repeat(v)))
 
-fn take(0, lst) -> [] 
+define take(0, lst) -> [] 
     | (1, [h, .._]) -> [h]
     | (_, []) -> []
     | (2, [h1, h2, .._]) -> [h1, h2]
@@ -14,28 +14,28 @@ fn take(0, lst) -> []
     | (_, acc, []) -> acc
     | (0, acc, _) -> acc
 
-fn take(n, acc, [h, ..r]) when n > 0 -> take(n - 1, [..acc, h], r)
+define take(n, acc, [h, ..r]) when n > 0 -> take(n - 1, [..acc, h], r)
 
 print(take(1, [1,2,3]))
 print(take(5, repeat("a")))
 
-fn interleve(l) -> l
-fn interleve(_, []) -> [] 
-fn interleve([], _) -> []
-fn interleve([h1, ..r1], [h2, ..r2]) -> [h1, h2, ..interleve(r1, r2)]
-fn interleve
+define interleve(l) -> l
+define interleve(_, []) -> [] 
+define interleve([], _) -> []
+define interleve([h1, ..r1], [h2, ..r2]) -> [h1, h2, ..interleve(r1, r2)]
+define interleve
       (_, [], _) -> [] 
     | ([], _, _) -> [] 
     | (_, _, []) -> [] 
     | ([h1, ..r1], [h2, ..r2], [h3, ..r3]) -> [h1, h2, h3, ..interleve(r1, r2, r3)]
-fn interleve
+define interleve
       (_, [], _, _) -> [] 
     | ([], _, _, _) -> [] 
     | (_, _, [], _) -> [] 
     | (_, _, _, []) -> [] 
     | ([h1, ..r1], [h2, ..r2], [h3, ..r3], [h4, ..r4]) -> [h1, h2, h3, h4, ..interleve(r1, r2, r3, r4)]
 
-fn concat([]) -> "" | (acc, []) -> acc | ([h, ..r]) -> concat(str(h), r) | (acc, [h, ..r]) -> concat(acc + str(h), r)
+define concat([]) -> "" | (acc, []) -> acc | ([h, ..r]) -> concat(str(h), r) | (acc, [h, ..r]) -> concat(acc + str(h), r)
 print(concat([1,2,3]))
 print(">>", concat(interleve([1,2,3], repeat(","), ["a", "b","c"], repeat("\n"))))
 

--- a/scripts/duplicates.genia
+++ b/scripts/duplicates.genia
@@ -1,7 +1,7 @@
-fn reduce(f, acc) -> fn(list) -> reduce(f, acc, list)
-fn reduce(_, acc, []) -> acc
-fn reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
+define reduce(f, acc) -> define(list) -> reduce(f, acc, list)
+define reduce(_, acc, []) -> acc
+define reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
 
-fn duplicates(value, n) -> reduce(fn(acc, _) -> [..acc, value], [], 1..n)
+define duplicates(value, n) -> reduce(define(acc, _) -> [..acc, value], [], 1..n)
 
 print(duplicates("x", 5))

--- a/scripts/example_script.genia
+++ b/scripts/example_script.genia
@@ -9,16 +9,16 @@ print("Number of arguments: " , NF);
 print("Arguments list: " , $ARGS);
 
 // Simple recursive function to calculate factorial
-fn factorial(0) -> 1;
-fn factorial(n) when n > 0 -> n * factorial(n - 1);
+define factorial(0) -> 1;
+define factorial(n) when n > 0 -> n * factorial(n - 1);
 
 // Call the factorial function
 print("Factorial of 5: " , factorial(5));
 
-fn rem(x,y) -> foreign "math.remainder" | (x) -> x
+define rem(x,y) -> foreign "math.remainder" | (x) -> x
 print("rem(10) = ", rem(10))
 printenv("rem")
 a = "GLOBAL"
-fn foo() -> (a = 1; b = 2; printenv("a"); (a + b))
+define foo() -> (a = 1; b = 2; printenv("a"); (a + b))
 print("FOO:", foo())    
 printenv()

--- a/scripts/fns.genia
+++ b/scripts/fns.genia
@@ -2,16 +2,16 @@ TRUE = 1 == 1
 FALSE = 1 == 2
 
 
-fn compose(f) -> fn(x) -> f(x)
-fn compose(f, g) -> fn(x) -> f(g(x))
-fn compose(f, g, h) -> fn(x) -> f(g(h(x)))
+define compose(f) -> define(x) -> f(x)
+define compose(f, g) -> define(x) -> f(g(x))
+define compose(f, g, h) -> define(x) -> f(g(h(x)))
 
-fn invert(pred) -> fn(x) when pred(x) -> FALSE | (x) -> TRUE
+define invert(pred) -> define(x) when pred(x) -> FALSE | (x) -> TRUE
 
-fn equal? (x) -> fn(y) -> x == y
+define equal? (x) -> define(y) -> x == y
     | (x, y) -> x == y
 
-fn constantly(v) -> fn(_) -> v 
+define constantly(v) -> define(_) -> v 
 
 trace()
 

--- a/scripts/os.genia
+++ b/scripts/os.genia
@@ -2,34 +2,34 @@ TRUE = 1 == 1
 FALSE = 1 == 2
 
 
-fn reduce(f, acc) -> fn(list) -> reduce(f, acc, list)
-fn reduce(_, acc, []) -> acc
-fn reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
+define reduce(f, acc) -> define(list) -> reduce(f, acc, list)
+define reduce(_, acc, []) -> acc
+define reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
 
-fn count([]) -> 0
-fn count(list) -> reduce(fn (acc, _) -> acc + 1, 0, list)
+define count([]) -> 0
+define count(list) -> reduce(define (acc, _) -> acc + 1, 0, list)
 
-fn filter(f) -> fn(list) -> filter(f, list)
-fn filter(_, []) -> []
-fn filter(pred, list) -> reduce(fn (acc, el) when pred(el) -> [..acc, el] | (acc, _) -> acc, [], list)
-fn not(v) when v -> FALSE | (_) -> TRUE
+define filter(f) -> define(list) -> filter(f, list)
+define filter(_, []) -> []
+define filter(pred, list) -> reduce(define (acc, el) when pred(el) -> [..acc, el] | (acc, _) -> acc, [], list)
+define not(v) when v -> FALSE | (_) -> TRUE
 
-fn grep (regex)                 -> (fn(list)    -> grep(regex, TRUE, list))
-    |   (regex, rtnval)         -> (fn(list)    -> grep(regex, rtnval, list))
+define grep (regex)                 -> (define(list)    -> grep(regex, TRUE, list))
+    |   (regex, rtnval)         -> (define(list)    -> grep(regex, rtnval, list))
     |   (regex, rtnval, seq)    ->  
             filter(
-                fn (el) when el ~ regex     -> rtnval 
+                define (el) when el ~ regex     -> rtnval 
                     | (_)                   -> not(rtnval),
                 seq)
 
 
 
 
-fn rcompose () -> (fn(x) -> x) 
-    | (f) -> (fn(x) -> f(x))
-    | (f, g) -> (fn(x) -> g(f(x)))
-    | (f, g, h) -> (fn(x) -> h(g(f(x))))
-    | (f, g, h, i) -> (fn(x) -> i(h(g(f(x)))))
+define rcompose () -> (define(x) -> x) 
+    | (f) -> (define(x) -> f(x))
+    | (f, g) -> (define(x) -> g(f(x)))
+    | (f, g, h) -> (define(x) -> h(g(f(x))))
+    | (f, g, h, i) -> (define(x) -> i(h(g(f(x)))))
 
 f = find_files(".")
 count(f)

--- a/scripts/seq.genia
+++ b/scripts/seq.genia
@@ -1,88 +1,88 @@
 TRUE = 1 == 1
 FALSE = 1 == 2
 
-fn reduce(f, acc) -> fn(list) -> reduce(f, acc, list)
-fn reduce(_, acc, []) -> acc
-fn reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
+define reduce(f, acc) -> define(list) -> reduce(f, acc, list)
+define reduce(_, acc, []) -> acc
+define reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
 
-fn count([]) -> 0
-fn count(list) -> reduce(fn (acc, _) -> acc + 1, 0, list)
+define count([]) -> 0
+define count(list) -> reduce(define (acc, _) -> acc + 1, 0, list)
 
-fn map(f) -> fn(list) -> map(f, list)
-fn map(_, []) -> []
-fn map(func, list) -> reduce(fn (acc, el) -> [..acc, func(el)], [], list)
+define map(f) -> define(list) -> map(f, list)
+define map(_, []) -> []
+define map(func, list) -> reduce(define (acc, el) -> [..acc, func(el)], [], list)
 
-fn filter(f) -> fn(list) -> filter(f, list)
-fn filter(_, []) -> []
-fn filter(pred, list) -> reduce(fn (acc, el) when pred(el) -> [..acc, el] | (acc, _) -> acc, [], list)
+define filter(f) -> define(list) -> filter(f, list)
+define filter(_, []) -> []
+define filter(pred, list) -> reduce(define (acc, el) when pred(el) -> [..acc, el] | (acc, _) -> acc, [], list)
 
-fn take(_, []) -> []
-fn take (n, seq) -> reduce(fn (acc, el) when count(acc) < n -> [..acc, el] | (acc, _) -> acc, [], seq)
-fn take(n) -> fn(seq) -> take(n, seq)
+define take(_, []) -> []
+define take (n, seq) -> reduce(define (acc, el) when count(acc) < n -> [..acc, el] | (acc, _) -> acc, [], seq)
+define take(n) -> define(seq) -> take(n, seq)
 
-fn reverse() -> fn(list) -> reverse(list)
-fn reverse([]) -> []
-fn reverse(list) -> reduce(fn (acc, el) -> [el, ..acc], [], list)
+define reverse() -> define(list) -> reverse(list)
+define reverse([]) -> []
+define reverse(list) -> reduce(define (acc, el) -> [el, ..acc], [], list)
 
-fn any?(pred) -> fn(list) -> any?(pred, list)
-fn any?(_, []) -> FALSE
-fn any?(pred, [head, ..tail]) when pred(head) -> TRUE
-fn any?(pred, [head, ..tail]) -> any?(pred, tail)
+define any?(pred) -> define(list) -> any?(pred, list)
+define any?(_, []) -> FALSE
+define any?(pred, [head, ..tail]) when pred(head) -> TRUE
+define any?(pred, [head, ..tail]) -> any?(pred, tail)
 
-fn every?(pred) -> fn(list) -> every?(pred, list)
-fn every?(_, []) -> TRUE
-fn every?(pred, [head, ..tail]) when pred(head) -> every?(pred, tail)
-fn every?(pred, [head, ..tail]) -> FALSE
+define every?(pred) -> define(list) -> every?(pred, list)
+define every?(_, []) -> TRUE
+define every?(pred, [head, ..tail]) when pred(head) -> every?(pred, tail)
+define every?(pred, [head, ..tail]) -> FALSE
 
-fn interpose(_, [])             -> []
-fn interpose(_, [h])            -> [h]
-fn interpose(item, [hf, ..r])   -> reduce(fn(acc, el) -> [..acc, item, el], [hf], r)
+define interpose(_, [])             -> []
+define interpose(_, [h])            -> [h]
+define interpose(item, [hf, ..r])   -> reduce(define(acc, el) -> [..acc, item, el], [hf], r)
 
-fn interleve(l) -> l
-fn interleve(l1, l2) -> interleve(l1, l2, [])
-fn interleve([], _, acc) -> reverse(acc)
+define interleve(l) -> l
+define interleve(l1, l2) -> interleve(l1, l2, [])
+define interleve([], _, acc) -> reverse(acc)
     | (_, [], acc) -> reverse(acc)
     | ([h1, ..r1], [h2, ..r2], acc) -> interleve(r1, r2, [h2, h1, ..acc])
-fn interleve(l1, l2, l3) -> interleve(l1, l2, l3, [])
-fn interleve([], _, _, acc) -> reverse(acc)
+define interleve(l1, l2, l3) -> interleve(l1, l2, l3, [])
+define interleve([], _, _, acc) -> reverse(acc)
     | (_, [], _, acc) -> reverse(acc)
     | (_, _, [], acc) -> reverse(acc)
     | ([h1, ..r1], [h2, ..r2], [h3, ..r3], acc) -> interleve(r1, r2, r3, [h3, h2, h1, ..acc])
-fn interleve(l1, l2, l3, l4) -> interleve(l1, l2, l3, l4, [])
-fn interleve([], _, _, _, acc) -> reverse(acc)
+define interleve(l1, l2, l3, l4) -> interleve(l1, l2, l3, l4, [])
+define interleve([], _, _, _, acc) -> reverse(acc)
     | (_, [], _, _, acc) -> reverse(acc)
     | (_, _, [], _, acc) -> reverse(acc)
     | (_, _, _, [], acc) -> reverse(acc)
     | ([h1, ..r1], [h2, ..r2], [h3, ..r3], [h4, ..r4], acc) -> interleve(r1, r2, r3, r4, [h4, h3, h2, h1, ..acc])
 
-fn distinct() -> []
-fn distinct([]) -> []
-fn distinct(list) -> distinct(list, [])
-fn distinct([], acc) -> reverse(acc)
-fn distinct([head, ..tail], acc) when any?(equal?(head), acc) -> distinct(tail, acc)
-fn distinct([head, ..tail], acc) -> distinct(tail, [head, ..acc])
+define distinct() -> []
+define distinct([]) -> []
+define distinct(list) -> distinct(list, [])
+define distinct([], acc) -> reverse(acc)
+define distinct([head, ..tail], acc) when any?(equal?(head), acc) -> distinct(tail, acc)
+define distinct([head, ..tail], acc) -> distinct(tail, [head, ..acc])
 
-fn nequal?(v) -> fn(y) -> v != y
+define nequal?(v) -> define(y) -> v != y
 
-fn distinct2() -> []
-fn distinct2([]) -> []
-fn distinct2(list) -> distinct2(list, [])
-fn distinct2([], acc) -> reverse(acc)
+define distinct2() -> []
+define distinct2([]) -> []
+define distinct2(list) -> distinct2(list, [])
+define distinct2([], acc) -> reverse(acc)
     | ([head, ..tail], acc) -> distinct2(filter(nequal?(head), tail), [head, ..acc])
 
 
-fn inc(i) -> i + 1
-fn iterate(f, v) -> delayseq(v, delay(iterate(f, f(v))))
-fn numbers () -> iterate(inc, 1)
+define inc(i) -> i + 1
+define iterate(f, v) -> delayseq(v, delay(iterate(f, f(v))))
+define numbers () -> iterate(inc, 1)
 [a,b,c] = numbers()
 print(a)  // prints 1
 print(b)  // prints 2
 print(c)  // prints 3
 
-fn add(x, y) -> x + y
-fn double(x) -> x + x
-fn pos?(x) -> x > 0
-fn npos?(x) -> x <= 0
+define add(x, y) -> x + y
+define double(x) -> x + x
+define pos?(x) -> x > 0
+define npos?(x) -> x <= 0
 
 ls = lazyseq([1,2,3])
 
@@ -90,7 +90,7 @@ print("Sum of numbers from 1 to 3: ", reduce(add, 0 1..3))
 print("Double the numbers from 10 to 20: ", map(double, 10..20))
 print("Only the positive numbers from -10 to 10:", filter(pos?, (-10)..10))
 
-fn double_pos(coll) ->
+define double_pos(coll) ->
     reverse(map(double, filter(pos? coll)))
 
 print("Double and reverse the positive numbers from -10 to 10:" , double_pos((-10)..10))

--- a/scripts/string.genia
+++ b/scripts/string.genia
@@ -1,11 +1,11 @@
-fn str(s) -> foreign "builtins.str"
+define str(s) -> foreign "builtins.str"
 
-fn join([])           -> "" 
+define join([])           -> "" 
     | (acc, [])       -> acc 
     | ([h, ..r])      -> join(str(h), r) 
     | (acc, [h, ..r]) -> join(acc + str(h), r)
 
-fn join-with(sep, []) -> []
+define join-with(sep, []) -> []
   | (sep, lst) -> join(interpose(sep, lst))
 
 print(join("a", [1,2,3]))

--- a/scripts/tic_tac_toe.genia
+++ b/scripts/tic_tac_toe.genia
@@ -1,64 +1,64 @@
-fn set_board(b, i, v) -> foreign "genia.hosted.tictactoe.set_board"
-fn input(prompt) -> foreign "builtins.input"
-fn int(s) -> foreign "builtins.int"
+define set_board(b, i, v) -> foreign "genia.hosted.tictactoe.set_board"
+define input(prompt) -> foreign "builtins.input"
+define int(s) -> foreign "builtins.int"
 
 TRUE  = 1 == 1
 FALSE = 1 == 2
 
-fn equal?(x) -> fn(y) -> x == y
+define equal?(x) -> define(y) -> x == y
     | (x, y) -> x == y
-fn equal?(a,b,c) when a == b -> b == c
-fn equal?(a,b,c) -> FALSE
-fn equal?(a,b,c,d) when a == b -> equal?(b,c,d)
-fn equal?(a,b,c,d) -> FALSE
+define equal?(a,b,c) when a == b -> b == c
+define equal?(a,b,c) -> FALSE
+define equal?(a,b,c,d) when a == b -> equal?(b,c,d)
+define equal?(a,b,c,d) -> FALSE
 
-fn nequal?(x) -> fn(y) -> x != y
+define nequal?(x) -> define(y) -> x != y
 
-fn every?(pred) -> fn(list) -> every?(pred, list)
-fn every?(_, []) -> TRUE
-fn every?(pred, [head, ..tail]) when pred(head) -> every?(pred, tail)
-fn every?(pred, [head, ..tail]) -> FALSE
+define every?(pred) -> define(list) -> every?(pred, list)
+define every?(_, []) -> TRUE
+define every?(pred, [head, ..tail]) when pred(head) -> every?(pred, tail)
+define every?(pred, [head, ..tail]) -> FALSE
 
-fn any?(pred) -> fn(list) -> any?(pred, list)
-fn any?(_, []) -> FALSE
-fn any?(pred, [head, .._]) when pred(head) -> TRUE
-fn any?(pred, [head, ..tail]) -> any?(pred, tail)
+define any?(pred) -> define(list) -> any?(pred, list)
+define any?(_, []) -> FALSE
+define any?(pred, [head, .._]) when pred(head) -> TRUE
+define any?(pred, [head, ..tail]) -> any?(pred, tail)
 
-fn reduce(f, acc) -> fn(list) -> reduce(f, acc, list)
-fn reduce(_, acc, []) -> acc
-fn reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
+define reduce(f, acc) -> define(list) -> reduce(f, acc, list)
+define reduce(_, acc, []) -> acc
+define reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
 
-fn map(f) -> fn(lst) -> map(f, lst)
-fn map(_, []) -> []
+define map(f) -> define(lst) -> map(f, lst)
+define map(_, []) -> []
     | (f, [h, ..r]) -> [f(h), ..map(f, r)]
 
-fn map(_, [], _) -> []
+define map(_, [], _) -> []
     | (_, _, []) -> []
     | (f, [h, ..r], [h2, ..r2]) -> [f(h, h2), ..map(f, r, r2)]
 
-fn add()  -> 0
-fn add(x) -> x | (x, y) -> x + y
+define add()  -> 0
+define add(x) -> x | (x, y) -> x + y
 
 print(map(add, [1]))
 print(map(add, [1,2,3], [10,11,12]))
 
-fn constantly(v) -> fn(_) -> v 
+define constantly(v) -> define(_) -> v 
 
-fn interpose(_, [])             -> []
-fn interpose(_, [h])            -> [h]
-fn interpose(item, [hf, ..r])   -> reduce(fn(acc, el) -> [..acc, item, el], [hf], r)
+define interpose(_, [])             -> []
+define interpose(_, [h])            -> [h]
+define interpose(item, [hf, ..r])   -> reduce(define(acc, el) -> [..acc, item, el], [hf], r)
 
-fn duplicates(value, n) -> map(constantly(value), 1..n)
+define duplicates(value, n) -> map(constantly(value), 1..n)
 
-data Trio = Trio(a,b,c)
+define Trio = Trio(a,b,c)
 
-fn board_full?([.._, " ", .._]) -> FALSE | (_) -> TRUE
+define board_full?([.._, " ", .._]) -> FALSE | (_) -> TRUE
 
-fn create-board() -> duplicates(" ", 9)
+define create-board() -> duplicates(" ", 9)
 
-fn as-trio() -> 0..7
-fn as-trio(b) -> fn(n) -> as-trio(b, n)
-fn as-trio
+define as-trio() -> 0..7
+define as-trio(b) -> define(n) -> as-trio(b, n)
+define as-trio
     ([a,b,c, .._], 0) -> Trio(a,b,c) 
     | ([ _,_,_,
         a,b,c, 
@@ -82,10 +82,10 @@ fn as-trio
         _,b,_,
         _,_,c], 7)      -> Trio(a,b,c) 
 
-fn trios(board) -> map(as-trio(board), as-trio())
+define trios(board) -> map(as-trio(board), as-trio())
 
-fn printer(Trio(a, b, c)) -> print(a + "|" + b  + "|" + c)
-fn printer(board) -> 
+define printer(Trio(a, b, c)) -> print(a + "|" + b  + "|" + c)
+define printer(board) -> 
 (
     print("");
     printer(as-trio(board, 0));
@@ -95,9 +95,9 @@ fn printer(board) ->
     printer(as-trio(board, 2));
 )
 
-fn check-win(p) -> fn(t) -> check-win(t, p)
-fn check-win(Trio(a, b, c), p) -> equal?(p, a, b, c) 
-fn check-win(board, p) ->
+define check-win(p) -> define(t) -> check-win(t, p)
+define check-win(Trio(a, b, c), p) -> equal?(p, a, b, c) 
+define check-win(board, p) ->
 (
     any?(
         check-win(p), 
@@ -105,9 +105,9 @@ fn check-win(board, p) ->
 )
 board = create-board()
 
-fn switch("X") -> "O" | (_) -> "X"
+define switch("X") -> "O" | (_) -> "X"
 
-fn game*
+define game*
       (p) when check-win(board, p) 
         ->  print("Player " + p + " wins!")
 
@@ -123,7 +123,7 @@ fn game*
         game(switch(p))
     )
 
-fn game(p) -> (
+define game(p) -> (
     printer(board);
     game*(p)
 )

--- a/scripts/wc.genia
+++ b/scripts/wc.genia
@@ -1,6 +1,6 @@
 # trace()
-# fn begin() -> c = 0
-fn end() -> print("    ", c)
+# define begin() -> c = 0
+define end() -> print("    ", c)
 
 
 print(NR, $6, $7, $9)

--- a/tests/test_adt.py
+++ b/tests/test_adt.py
@@ -7,7 +7,7 @@ from genia.interpreter import GENIAInterpreter
 
 def test_adt_constructor():
     code = """
-    data Option = Some(a) | None
+    define Option = Some(a) | None
     Some(5)
     """
     interp = GENIAInterpreter()
@@ -17,8 +17,8 @@ def test_adt_constructor():
 
 def test_adt_pattern_match():
     code = """
-    data Option = Some(a) | None
-    fn unwrap(Some(x)) -> x | (None()) -> 0
+    define Option = Some(a) | None
+    define unwrap(Some(x)) -> x | (None()) -> 0
     unwrap(Some(7))
     """
     interp = GENIAInterpreter()
@@ -27,8 +27,8 @@ def test_adt_pattern_match():
 
 def test_adt_pattern_match_none():
     code = """
-    data Option = Some(a) | None
-    fn unwrap(Some(x)) -> x | (None()) -> 0
+    define Option = Some(a) | None
+    define unwrap(Some(x)) -> x | (None()) -> 0
     unwrap(None())
     """
     interp = GENIAInterpreter()
@@ -37,7 +37,7 @@ def test_adt_pattern_match_none():
 
 def test_trio_constructor():
     code = """
-    data Trio = Trio(a, b, c)
+    define Trio = Trio(a, b, c)
     Trio(1, 2, 3)
     """
     interp = GENIAInterpreter()
@@ -47,8 +47,8 @@ def test_trio_constructor():
 
 def test_trio_pattern_match():
     code = """
-    data Trio = Trio(a, b, c)
-    fn sum_trio(Trio(x, y, z)) -> x + y + z
+    define Trio = Trio(a, b, c)
+    define sum_trio(Trio(x, y, z)) -> x + y + z
     sum_trio(Trio(1, 2, 3))
     """
     interp = GENIAInterpreter()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,14 +11,14 @@ def test_board_full_without_ffi():
     TRUE  = 1 == 1
     FALSE = 1 == 2
 
-    fn equal?(x) -> fn(y) -> x == y | (x, y) -> x == y
+    define equal?(x) -> define(y) -> x == y | (x, y) -> x == y
 
-    fn every?(pred) -> fn(list) -> every?(pred, list)
-    fn every?(_, []) -> TRUE
-    fn every?(pred, [head, ..tail]) when pred(head) -> every?(pred, tail)
-    fn every?(pred, [head, ..tail]) -> FALSE
+    define every?(pred) -> define(list) -> every?(pred, list)
+    define every?(_, []) -> TRUE
+    define every?(pred, [head, ..tail]) when pred(head) -> every?(pred, tail)
+    define every?(pred, [head, ..tail]) -> FALSE
 
-    fn board_full(b) -> every?(fn(x) -> x != " ", b)
+    define board_full(b) -> every?(define(x) -> x != " ", b)
     board_full(["X","O","X","O","X","O","X","O","X"])
     """
     interp = GENIAInterpreter()
@@ -27,11 +27,11 @@ def test_board_full_without_ffi():
 
 def test_duplicate_with_reduce():
     code = """
-    fn reduce(f, acc) -> fn(list) -> reduce(f, acc, list)
-    fn reduce(_, acc, []) -> acc
-    fn reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
+    define reduce(f, acc) -> define(list) -> reduce(f, acc, list)
+    define reduce(_, acc, []) -> acc
+    define reduce(func, acc, [f, ..r]) -> reduce(func, func(acc, f), r)
 
-    fn duplicates(v, n) -> reduce(fn(acc, _) -> [..acc, v], [], 1..n)
+    define duplicates(v, n) -> reduce(define(acc, _) -> [..acc, v], [], 1..n)
     duplicates(5, 3)
     """
     interp = GENIAInterpreter()
@@ -39,7 +39,7 @@ def test_duplicate_with_reduce():
 
 def test_string_pattern_matching():
     code = """
-    fn switch("X") -> "O" | (_) -> "X"
+    define switch("X") -> "O" | (_) -> "X"
     switch("X")
     """
     interp = GENIAInterpreter()
@@ -54,7 +54,7 @@ def test_simple_assigment():
     
 def test_local_assigment():
     code = """
-    fn f() -> (x = 2)
+    define f() -> (x = 2)
     f()
     """
     interp = GENIAInterpreter()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -80,104 +80,104 @@ def test_identifier_with_dollar():
     assert tokens == expected_tokens
 
 def test_pipe_operator():
-    code = "fn foo() -> 0 | (_) -> 1;"
+    code = "define foo() -> 0 | (_) -> 1;"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'foo', 1, 4),
-        ('PUNCTUATION', '(', 1, 7),
-        ('PUNCTUATION', ')', 1, 8),
-        ('ARROW', '->', 1, 10),
-        ('NUMBER', '0', 1, 13),
-        ('PUNCTUATION', '|', 1, 15),
-        ('PUNCTUATION', '(', 1, 17),
-        ('IDENTIFIER', '_', 1, 18),
-        ('PUNCTUATION', ')', 1, 19),
-        ('ARROW', '->', 1, 21),
-        ('NUMBER', '1', 1, 24),
-        ('PUNCTUATION', ';', 1, 25),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'foo', 1, 8),
+        ('PUNCTUATION', '(', 1, 11),
+        ('PUNCTUATION', ')', 1, 12),
+        ('ARROW', '->', 1, 14),
+        ('NUMBER', '0', 1, 17),
+        ('PUNCTUATION', '|', 1, 19),
+        ('PUNCTUATION', '(', 1, 21),
+        ('IDENTIFIER', '_', 1, 22),
+        ('PUNCTUATION', ')', 1, 23),
+        ('ARROW', '->', 1, 25),
+        ('NUMBER', '1', 1, 28),
+        ('PUNCTUATION', ';', 1, 29),
     ]
     assert tokens == expected_tokens
 
 def test_lexer_pipe_and_anonymous_function():
-    code = "c = fn () -> 0 | (_) -> 1"
+    code = "c = define () -> 0 | (_) -> 1"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('IDENTIFIER', 'c', 1, 1), 
+        ('IDENTIFIER', 'c', 1, 1),
         ('OPERATOR', '=', 1, 3),
-        ('KEYWORD', 'fn', 1, 5), 
-        ('PUNCTUATION', '(', 1, 8), 
-        ('PUNCTUATION', ')', 1, 9), 
-        ('ARROW', '->', 1, 11), 
-        ('NUMBER', '0', 1, 14),
-        ('PUNCTUATION', '|', 1, 16),
-        ('PUNCTUATION', '(', 1, 18),
-        ('IDENTIFIER', '_', 1, 19), 
-        ('PUNCTUATION', ')', 1, 20), 
-        ('ARROW', '->', 1, 22),
-        ('NUMBER', '1', 1, 25),
+        ('KEYWORD', 'define', 1, 5),
+        ('PUNCTUATION', '(', 1, 12),
+        ('PUNCTUATION', ')', 1, 13),
+        ('ARROW', '->', 1, 15),
+        ('NUMBER', '0', 1, 18),
+        ('PUNCTUATION', '|', 1, 20),
+        ('PUNCTUATION', '(', 1, 22),
+        ('IDENTIFIER', '_', 1, 23),
+        ('PUNCTUATION', ')', 1, 24),
+        ('ARROW', '->', 1, 26),
+        ('NUMBER', '1', 1, 29),
     ]
 
     assert tokens == expected_tokens
 
 def test_lexer_nested_function():
-    code = "fn cons() -> fn () -> 0"
+    code = "define cons() -> define () -> 0"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'cons', 1, 4),
-        ('PUNCTUATION', '(', 1, 8),
-        ('PUNCTUATION', ')', 1, 9),
-        ('ARROW', '->', 1, 11),
-        ('KEYWORD', 'fn', 1, 14),
-        ('PUNCTUATION', '(', 1, 17),
-        ('PUNCTUATION', ')', 1, 18),
-        ('ARROW', '->', 1, 20),
-        ('NUMBER', '0', 1, 23),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'cons', 1, 8),
+        ('PUNCTUATION', '(', 1, 12),
+        ('PUNCTUATION', ')', 1, 13),
+        ('ARROW', '->', 1, 15),
+        ('KEYWORD', 'define', 1, 18),
+        ('PUNCTUATION', '(', 1, 25),
+        ('PUNCTUATION', ')', 1, 26),
+        ('ARROW', '->', 1, 28),
+        ('NUMBER', '0', 1, 31),
     ]
     
     assert tokens == expected_tokens
 
 def test_lexer_tokenizes_foreign_keyword_with_positions():
-    code = "foreign fn print(a) -> ;"
+    code = "foreign define print(a) -> ;"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
         ('KEYWORD', 'foreign', 1, 1),
-        ('KEYWORD', 'fn', 1, 9),
-        ('IDENTIFIER', 'print', 1, 12),
-        ('PUNCTUATION', '(', 1, 17),
-        ('IDENTIFIER', 'a', 1, 18),
-        ('PUNCTUATION', ')', 1, 19),
-        ('ARROW', '->', 1, 21),
-        ('PUNCTUATION', ';', 1, 24),
+        ('KEYWORD', 'define', 1, 9),
+        ('IDENTIFIER', 'print', 1, 16),
+        ('PUNCTUATION', '(', 1, 21),
+        ('IDENTIFIER', 'a', 1, 22),
+        ('PUNCTUATION', ')', 1, 23),
+        ('ARROW', '->', 1, 25),
+        ('PUNCTUATION', ';', 1, 28),
     ]
 
     assert tokens == expected_tokens
 
 def test_lexer_handles_multiple_lines():
     code = textwrap.dedent("""\
-        fn add(a, b) ->
+        define add(a, b) ->
           a + b;""")
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'add', 1, 4),
-        ('PUNCTUATION', '(', 1, 7),
-        ('IDENTIFIER', 'a', 1, 8),
-        ('PUNCTUATION', ',', 1, 9),
-        ('IDENTIFIER', 'b', 1, 11),
-        ('PUNCTUATION', ')', 1, 12),
-        ('ARROW', '->', 1, 14),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'add', 1, 8),
+        ('PUNCTUATION', '(', 1, 11),
+        ('IDENTIFIER', 'a', 1, 12),
+        ('PUNCTUATION', ',', 1, 13),
+        ('IDENTIFIER', 'b', 1, 15),
+        ('PUNCTUATION', ')', 1, 16),
+        ('ARROW', '->', 1, 18),
         ('IDENTIFIER', 'a', 2, 3),
         ('OPERATOR', '+', 2, 5),
         ('IDENTIFIER', 'b', 2, 7),
@@ -187,68 +187,68 @@ def test_lexer_handles_multiple_lines():
     assert tokens == expected_tokens
 
 def test_lexer_raises_error_with_position():
-    code = "fn invalid $"
+    code = "define invalid $"
     lexer = Lexer(code)
     
     with pytest.raises(Lexer.SyntaxError) as exc_info:
         list(lexer.tokenize())
-    assert "Unexpected character '$' at line 1, column 12" in str(exc_info.value)
+    assert "Unexpected character '$' at line 1, column 16" in str(exc_info.value)
 
 def test_lexer_unicode_identifiers():
-    code = "fn example(xαβγ?, y*ζ) -> xαβγ? + y*ζ*"
+    code = "define example(xαβγ?, y*ζ) -> xαβγ? + y*ζ*"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'example', 1, 4),
-        ('PUNCTUATION', '(', 1, 11),
-        ('IDENTIFIER', 'xαβγ?', 1, 12),
-        ('PUNCTUATION', ',', 1, 17),
-        ('IDENTIFIER', 'y*ζ', 1, 19),
-        ('PUNCTUATION', ')', 1, 22),
-        ('ARROW', '->', 1, 24),
-        ('IDENTIFIER', 'xαβγ?', 1, 27),
-        ('OPERATOR', '+', 1, 33),
-        ('IDENTIFIER', 'y*ζ*', 1, 35),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'example', 1, 8),
+        ('PUNCTUATION', '(', 1, 15),
+        ('IDENTIFIER', 'xαβγ?', 1, 16),
+        ('PUNCTUATION', ',', 1, 21),
+        ('IDENTIFIER', 'y*ζ', 1, 23),
+        ('PUNCTUATION', ')', 1, 26),
+        ('ARROW', '->', 1, 28),
+        ('IDENTIFIER', 'xαβγ?', 1, 31),
+        ('OPERATOR', '+', 1, 37),
+        ('IDENTIFIER', 'y*ζ*', 1, 39),
     ]
 
     assert tokens == expected
 
 def test_basic_tokens():
-    code = "fn map (func, [first, ..rest]) -> [func(first), ..map(func, rest)];"
+    code = "define map (func, [first, ..rest]) -> [func(first), ..map(func, rest)];"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'map', 1, 4),
-        ('PUNCTUATION', '(', 1, 8),
-        ('IDENTIFIER', 'func', 1, 9),
-        ('PUNCTUATION', ',', 1, 13),
-        ('PUNCTUATION', '[', 1, 15),
-        ('IDENTIFIER', 'first', 1, 16),
-        ('PUNCTUATION', ',', 1, 21),
-        ('OPERATOR', '..', 1, 23),
-        ('IDENTIFIER', 'rest', 1, 25),
-        ('PUNCTUATION', ']', 1, 29),
-        ('PUNCTUATION', ')', 1, 30),
-        ('ARROW', '->', 1, 32),
-        ('PUNCTUATION', '[', 1, 35),
-        ('IDENTIFIER', 'func', 1, 36),
-        ('PUNCTUATION', '(', 1, 40),
-        ('IDENTIFIER', 'first', 1, 41),
-        ('PUNCTUATION', ')', 1, 46),
-        ('PUNCTUATION', ',', 1, 47),
-        ('OPERATOR', '..', 1, 49),
-        ('IDENTIFIER', 'map', 1, 51),
-        ('PUNCTUATION', '(', 1, 54),
-        ('IDENTIFIER', 'func', 1, 55),
-        ('PUNCTUATION', ',', 1, 59),
-        ('IDENTIFIER', 'rest', 1, 61),
-        ('PUNCTUATION', ')', 1, 65),
-        ('PUNCTUATION', ']', 1, 66),
-        ('PUNCTUATION', ';', 1, 67),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'map', 1, 8),
+        ('PUNCTUATION', '(', 1, 12),
+        ('IDENTIFIER', 'func', 1, 13),
+        ('PUNCTUATION', ',', 1, 17),
+        ('PUNCTUATION', '[', 1, 19),
+        ('IDENTIFIER', 'first', 1, 20),
+        ('PUNCTUATION', ',', 1, 25),
+        ('OPERATOR', '..', 1, 27),
+        ('IDENTIFIER', 'rest', 1, 29),
+        ('PUNCTUATION', ']', 1, 33),
+        ('PUNCTUATION', ')', 1, 34),
+        ('ARROW', '->', 1, 36),
+        ('PUNCTUATION', '[', 1, 39),
+        ('IDENTIFIER', 'func', 1, 40),
+        ('PUNCTUATION', '(', 1, 44),
+        ('IDENTIFIER', 'first', 1, 45),
+        ('PUNCTUATION', ')', 1, 50),
+        ('PUNCTUATION', ',', 1, 51),
+        ('OPERATOR', '..', 1, 53),
+        ('IDENTIFIER', 'map', 1, 55),
+        ('PUNCTUATION', '(', 1, 58),
+        ('IDENTIFIER', 'func', 1, 59),
+        ('PUNCTUATION', ',', 1, 63),
+        ('IDENTIFIER', 'rest', 1, 65),
+        ('PUNCTUATION', ')', 1, 69),
+        ('PUNCTUATION', ']', 1, 70),
+        ('PUNCTUATION', ';', 1, 71),
     ]
     assert tokens == expected
 
@@ -297,92 +297,92 @@ def test_end_of_list():
     assert tokens == expected
 
 def test_parser_list_pattern_tokens():
-    code = "fn foo([_, ..r]) -> [99, ..r]"
+    code = "define foo([_, ..r]) -> [99, ..r]"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'foo', 1, 4),
-        ('PUNCTUATION', '(', 1, 7),
-        ('PUNCTUATION', '[', 1, 8),
-        ('IDENTIFIER', '_', 1, 9),
-        ('PUNCTUATION', ',', 1, 10),
-        ('OPERATOR', '..', 1, 12),
-        ('IDENTIFIER', 'r', 1, 14),
-        ('PUNCTUATION', ']', 1, 15),
-        ('PUNCTUATION', ')', 1, 16),
-        ('ARROW', '->', 1, 18),
-        ('PUNCTUATION', '[', 1, 21),
-        ('NUMBER', '99', 1, 22),
-        ('PUNCTUATION', ',', 1, 24),
-        ('OPERATOR', '..', 1, 26),
-        ('IDENTIFIER', 'r', 1, 28),
-        ('PUNCTUATION', ']', 1, 29),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'foo', 1, 8),
+        ('PUNCTUATION', '(', 1, 11),
+        ('PUNCTUATION', '[', 1, 12),
+        ('IDENTIFIER', '_', 1, 13),
+        ('PUNCTUATION', ',', 1, 14),
+        ('OPERATOR', '..', 1, 16),
+        ('IDENTIFIER', 'r', 1, 18),
+        ('PUNCTUATION', ']', 1, 19),
+        ('PUNCTUATION', ')', 1, 20),
+        ('ARROW', '->', 1, 22),
+        ('PUNCTUATION', '[', 1, 25),
+        ('NUMBER', '99', 1, 26),
+        ('PUNCTUATION', ',', 1, 28),
+        ('OPERATOR', '..', 1, 30),
+        ('IDENTIFIER', 'r', 1, 32),
+        ('PUNCTUATION', ']', 1, 33),
     ]
 
     assert tokens == expected_tokens
 
 def test_multiple_statements_in_function():
-    code = "fn foo() -> (a = 1; b = 2; a + b)"
+    code = "define foo() -> (a = 1; b = 2; a + b)"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'foo', 1, 4),
-        ('PUNCTUATION', '(', 1, 7),
-        ('PUNCTUATION', ')', 1, 8),
-        ('ARROW', '->', 1, 10),
-        ('PUNCTUATION', '(', 1, 13),
-        ('IDENTIFIER', 'a', 1, 14),
-        ('OPERATOR', '=', 1, 16),
-        ('NUMBER', '1', 1, 18),
-        ('PUNCTUATION', ';', 1, 19),
-        ('IDENTIFIER', 'b', 1, 21),
-        ('OPERATOR', '=', 1, 23),
-        ('NUMBER', '2', 1, 25),
-        ('PUNCTUATION', ';', 1, 26),
-        ('IDENTIFIER', 'a', 1, 28),
-        ('OPERATOR', '+', 1, 30),
-        ('IDENTIFIER', 'b', 1, 32),
-        ('PUNCTUATION', ')', 1, 33),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'foo', 1, 8),
+        ('PUNCTUATION', '(', 1, 11),
+        ('PUNCTUATION', ')', 1, 12),
+        ('ARROW', '->', 1, 14),
+        ('PUNCTUATION', '(', 1, 17),
+        ('IDENTIFIER', 'a', 1, 18),
+        ('OPERATOR', '=', 1, 20),
+        ('NUMBER', '1', 1, 22),
+        ('PUNCTUATION', ';', 1, 23),
+        ('IDENTIFIER', 'b', 1, 25),
+        ('OPERATOR', '=', 1, 27),
+        ('NUMBER', '2', 1, 29),
+        ('PUNCTUATION', ';', 1, 30),
+        ('IDENTIFIER', 'a', 1, 32),
+        ('OPERATOR', '+', 1, 34),
+        ('IDENTIFIER', 'b', 1, 36),
+        ('PUNCTUATION', ')', 1, 37),
     ]
     assert tokens == expected_tokens
 
 def test_nested_grouped_statements():
-    code = "fn bar() -> (x = (y = 1; z = 2; y * z); x + 5);"
+    code = "define bar() -> (x = (y = 1; z = 2; y * z); x + 5);"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'bar', 1, 4),
-        ('PUNCTUATION', '(', 1, 7),
-        ('PUNCTUATION', ')', 1, 8),
-        ('ARROW', '->', 1, 10),
-        ('PUNCTUATION', '(', 1, 13),
-        ('IDENTIFIER', 'x', 1, 14),
-        ('OPERATOR', '=', 1, 16),
-        ('PUNCTUATION', '(', 1, 18),
-        ('IDENTIFIER', 'y', 1, 19),
-        ('OPERATOR', '=', 1, 21),
-        ('NUMBER', '1', 1, 23),
-        ('PUNCTUATION', ';', 1, 24),
-        ('IDENTIFIER', 'z', 1, 26),
-        ('OPERATOR', '=', 1, 28),
-        ('NUMBER', '2', 1, 30),
-        ('PUNCTUATION', ';', 1, 31),
-        ('IDENTIFIER', 'y', 1, 33),
-        ('OPERATOR', '*', 1, 35),
-        ('IDENTIFIER', 'z', 1, 37),
-        ('PUNCTUATION', ')', 1, 38),
-        ('PUNCTUATION', ';', 1, 39),
-        ('IDENTIFIER', 'x', 1, 41),
-        ('OPERATOR', '+', 1, 43),
-        ('NUMBER', '5', 1, 45),
-        ('PUNCTUATION', ')', 1, 46),
-        ('PUNCTUATION', ';', 1, 47),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'bar', 1, 8),
+        ('PUNCTUATION', '(', 1, 11),
+        ('PUNCTUATION', ')', 1, 12),
+        ('ARROW', '->', 1, 14),
+        ('PUNCTUATION', '(', 1, 17),
+        ('IDENTIFIER', 'x', 1, 18),
+        ('OPERATOR', '=', 1, 20),
+        ('PUNCTUATION', '(', 1, 22),
+        ('IDENTIFIER', 'y', 1, 23),
+        ('OPERATOR', '=', 1, 25),
+        ('NUMBER', '1', 1, 27),
+        ('PUNCTUATION', ';', 1, 28),
+        ('IDENTIFIER', 'z', 1, 30),
+        ('OPERATOR', '=', 1, 32),
+        ('NUMBER', '2', 1, 34),
+        ('PUNCTUATION', ';', 1, 35),
+        ('IDENTIFIER', 'y', 1, 37),
+        ('OPERATOR', '*', 1, 39),
+        ('IDENTIFIER', 'z', 1, 41),
+        ('PUNCTUATION', ')', 1, 42),
+        ('PUNCTUATION', ';', 1, 43),
+        ('IDENTIFIER', 'x', 1, 45),
+        ('OPERATOR', '+', 1, 47),
+        ('NUMBER', '5', 1, 49),
+        ('PUNCTUATION', ')', 1, 50),
+        ('PUNCTUATION', ';', 1, 51),
     ]
     assert tokens == expected_tokens
 
@@ -447,7 +447,7 @@ def test_invalid_raw_string():
 def test_mixed_code():
     code = textwrap.dedent("""\
 r"[A-Z]+\s" "regular\nstring"
-fn example -> print("Hello")
+define example -> print("Hello")
 """)
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
@@ -455,13 +455,13 @@ fn example -> print("Hello")
     expected_tokens = [
         ('RAW_STRING', '[A-Z]+\\s', 1, 1),        # Quotes removed
         ('STRING', 'regular\nstring', 1, 13),
-        ('KEYWORD', 'fn', 2, 1),
-        ('IDENTIFIER', 'example', 2, 4),
-        ('ARROW', '->', 2, 12),
-        ('IDENTIFIER', 'print', 2, 15),
-        ('PUNCTUATION', '(', 2, 20),
-        ('STRING', 'Hello', 2, 21),
-        ('PUNCTUATION', ')', 2, 28),
+        ('KEYWORD', 'define', 2, 1),
+        ('IDENTIFIER', 'example', 2, 8),
+        ('ARROW', '->', 2, 16),
+        ('IDENTIFIER', 'print', 2, 19),
+        ('PUNCTUATION', '(', 2, 24),
+        ('STRING', 'Hello', 2, 25),
+        ('PUNCTUATION', ')', 2, 32),
     ]
     assert tokens == expected_tokens
 
@@ -483,20 +483,20 @@ def test_lexer_recognizes_delay_keyword():
 
 # 2. Test if the lexer handles a combination of keywords and identifiers with delay
 def test_lexer_handles_keywords_and_identifiers():
-    code = "fn delay_value = delay(expensive_computation())"
+    code = "define delay_value = delay(expensive_computation())"
     tokens = tokenize(code)
     # print(tokens)  # Remove or comment out after verification
 
     expected_tokens = [
-        ('KEYWORD', 'fn', 1, 1),
-        ('IDENTIFIER', 'delay_value', 1, 4),
-        ('OPERATOR', '=', 1, 16),
-        ('KEYWORD', 'delay', 1, 18),
-        ('PUNCTUATION', '(', 1, 23),
-        ('IDENTIFIER', 'expensive_computation', 1, 24),
-        ('PUNCTUATION', '(', 1, 45),
-        ('PUNCTUATION', ')', 1, 46),
-        ('PUNCTUATION', ')', 1, 47),
+        ('KEYWORD', 'define', 1, 1),
+        ('IDENTIFIER', 'delay_value', 1, 8),
+        ('OPERATOR', '=', 1, 20),
+        ('KEYWORD', 'delay', 1, 22),
+        ('PUNCTUATION', '(', 1, 27),
+        ('IDENTIFIER', 'expensive_computation', 1, 28),
+        ('PUNCTUATION', '(', 1, 49),
+        ('PUNCTUATION', ')', 1, 50),
+        ('PUNCTUATION', ')', 1, 51),
     ]
     assert tokens == expected_tokens
 

--- a/tests/test_nested_import.py
+++ b/tests/test_nested_import.py
@@ -8,8 +8,8 @@ from genia.interpreter import GENIAInterpreter
 
 def test_nested_module_import():
     code = """
-    fn create_board() -> foreign "genia.hosted.tictactoe.create_board"
-    fn check_win(b, p) -> foreign "genia.hosted.tictactoe.check_win"
+    define create_board() -> foreign "genia.hosted.tictactoe.create_board"
+    define check_win(b, p) -> foreign "genia.hosted.tictactoe.check_win"
     board = create_board()
     check_win(board, "X")
     """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -149,7 +149,7 @@ def test_custom_function_call():
 
 
 def test_multi_arity_function_definition():
-    code = """fn add() -> 0
+    code = """define add() -> 0
 | (a) -> a
 | (a, b) -> a + b
 """
@@ -200,7 +200,7 @@ def test_multi_arity_function_definition():
 
 
 def test_function_with_guard():
-    code = "fn fact(n) when n > 1 -> n * fact(n - 1)"
+    code = "define fact(n) when n > 1 -> n * fact(n - 1)"
     lexer = Lexer(code)
     tokens = lexer.tokenize()
 
@@ -247,7 +247,7 @@ def test_function_with_guard():
 
 
 def test_multi_arity_with_guards():
-    code = """fn foo(x) when x > 10 -> x
+    code = """define foo(x) when x > 10 -> x
 | (x) when x < 5 -> x + 1
 """
     lexer = Lexer(code)
@@ -296,7 +296,7 @@ def test_multi_arity_with_guards():
 
 
 def test_ffi_simple():
-    code = 'fn rem(x,y) -> foreign "math.remainder"'
+    code = 'define rem(x,y) -> foreign "math.remainder"'
     lexer = Lexer(code)
     tokens = lexer.tokenize()
     parser = Parser(tokens)
@@ -436,7 +436,7 @@ start..end
 
 
 def test_parser_list_pattern_ast():
-    code = "fn foo([_, ..r]) -> [99, ..r]"
+    code = "define foo([_, ..r]) -> [99, ..r]"
     ast = parse(code)
     expected_ast = [
         {
@@ -471,7 +471,7 @@ def test_parser_list_pattern_ast():
 
 
 def test_parser_grouped_expression():
-    code = "fn foo() -> (a + b);"
+    code = "define foo() -> (a + b);"
     ast = parse(code)
 
     expected_ast = [
@@ -503,7 +503,7 @@ def test_parser_grouped_expression():
 
 
 def test_parser_grouped_statements():
-    code = "fn bar() -> (a = 1; b = 2; a + b);"
+    code = "define bar() -> (a = 1; b = 2; a + b);"
     ast = parse(code)
 
     expected_ast = [
@@ -675,7 +675,7 @@ def test_parser_nested_delay():
 
 
 def test_parser_delay_in_function_call():
-    code = "fn compute() -> delay(expensive_computation())"
+    code = "define compute() -> delay(expensive_computation())"
     ast = parse(code)
     expected_ast = [
         {
@@ -710,7 +710,7 @@ def test_parser_delay_in_function_call():
 
 
 def test_parser_named_function_with_literal():
-    code = "fn fact(0) -> 1;"
+    code = "define fact(0) -> 1;"
     lexer = Lexer(code)
     tokens = list(lexer.tokenize())
     parser = Parser(tokens)
@@ -737,7 +737,7 @@ def test_parser_named_function_with_literal():
 
 
 def test_parser_anonymous_function():
-    code = "fn (y) -> y + 1;"
+    code = "define (y) -> y + 1;"
     lexer = Lexer(code)
     tokens = list(lexer.tokenize())
     parser = Parser(tokens)
@@ -775,11 +775,11 @@ def test_parser_multiple_spread_operators():
     Test parsing of a function definition with multiple spread operators in list patterns.
 
     Function Definition:
-        fn process([..a, ..b]) -> [..a, ..b]
+        define process([..a, ..b]) -> [..a, ..b]
 
 
     """
-    code = "fn process([..a, ..b]) -> [..a, ..b]"
+    code = "define process([..a, ..b]) -> [..a, ..b]"
     ast = parse(code)
 
     expected_ast = [
@@ -789,7 +789,7 @@ def test_parser_multiple_spread_operators():
     assert strip_metadata(ast) == strip_metadata(
         expected_ast), f"Expected AST does not match actual AST.\nExpected: {expected_ast}\nActual: {ast}"
 def test_tail_call():
-    code = "fn fact_tail(n) when n > 1 -> fact_tail(n - 1)"
+    code = "define fact_tail(n) when n > 1 -> fact_tail(n - 1)"
     lexer = Lexer(code)
     tokens = lexer.tokenize()
 

--- a/tests/test_seq_functions.py
+++ b/tests/test_seq_functions.py
@@ -8,9 +8,9 @@ from genia.interpreter import GENIAInterpreter
 # Load base functions directly from scripts/seq.genia up to the utility section
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / 'scripts' / 'seq.genia'
 FILE_CONTENT = SCRIPT_PATH.read_text()
-BASE_FUNCTIONS = FILE_CONTENT.split('fn inc')[0]
+BASE_FUNCTIONS = FILE_CONTENT.split('define inc')[0]
 # Provide missing helper used by distinct
-BASE_FUNCTIONS += "\nfn equal?(x) -> fn(y) -> x == y | (x, y) -> x == y"
+BASE_FUNCTIONS += "\ndefine equal?(x) -> define(y) -> x == y | (x, y) -> x == y"
 
 def run(code: str):
     interp = GENIAInterpreter()


### PR DESCRIPTION
## Summary
- unify `fn` and `data` keywords under single `define`
- update lexer and parser for new keyword
- adjust interpreter example and documentation
- update scripts and tests for `define`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878013a6c9c83298009598bb44fa41c