### PR TITLE
Move randint into dice script

### DIFF
--- a/genia/interpreter.py
+++ b/genia/interpreter.py
@@ -434,11 +434,6 @@ class Interpreter:
         self.register_foreign_function("randrange", randrange, parameters=["start", "stop"])
         self.register_foreign_function("randrange", randrange, parameters=["start", "stop", "step"])
 
-        # Define native randint in terms of randrange
-        lexer = Lexer("define randint(a, b) -> randrange(a, b + 1)")
-        parser = Parser(lexer.tokenize())
-        for stmt in parser.parse():
-            self.evaluate(stmt)
         for i in range(1, 8):
             params = [f"msg{j}" for j in range(1, i + 1)]
             self.register_foreign_function("print", self.write_to_stdout, parameters=params)

--- a/scripts/dice.genia
+++ b/scripts/dice.genia
@@ -1,3 +1,5 @@
+define randint(a, b) -> randrange(a, b + 1)
+
 define roll(sides) -> roll(1, sides)
 define roll(0, _) -> 0
 define roll(n, sides) -> randint(1, sides) + roll(n - 1, sides)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,5 +1,14 @@
 import random
+from pathlib import Path
 from genia.interpreter import GENIAInterpreter
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / 'scripts' / 'dice.genia'
+FILE_CONTENT = SCRIPT_PATH.read_text()
+BASE_FUNCTIONS = FILE_CONTENT.split('[count, sides]')[0]
+
+def run(code: str):
+    interp = GENIAInterpreter()
+    return interp.run(BASE_FUNCTIONS + '\n' + code)
 
 
 def test_randrange_foreign_function():
@@ -12,21 +21,13 @@ def test_randrange_foreign_function():
 
 def test_randint_native_function():
     random.seed(0)
-    interp = GENIAInterpreter()
-    result = interp.run("randint(1, 6)")
+    result = run("randint(1, 6)")
     assert result == 4
 
 
 def test_roll_function():
     random.seed(0)
-    code = """
-define roll(sides) -> roll(1, sides)
-define roll(0, _) -> 0
-define roll(n, sides) -> randint(1, sides) + roll(n - 1, sides)
-roll(2, 6)
-"""
-    interp = GENIAInterpreter()
-    result = interp.run(code)
+    result = run("roll(2, 6)")
     assert result == 8
 
 


### PR DESCRIPTION
## Summary
- remove `randint` definition from `GENIAInterpreter`
- define `randint` inside `scripts/dice.genia`
- adjust random tests to load definitions from `dice.genia`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687810c42f148329b1b30369542214c9