### PR TITLE
Move randint into dice script

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ python -m genia_interpreter scripts/dice.genia 2 6
 ### Anthropic MCP Service
 
 This repository also includes a small HTTP service that exposes the `roll`
-function for use with Anthropic's MCP tools. Start the service and send it a
+function for use with Anthropic's MCP tools. The request-handling logic is
+implemented in the `dice.genia` script itself. Start the service and send it a
 request as follows:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Run a 2d6 roll:
 python -m genia_interpreter scripts/dice.genia 2 6
 ```
 
+### Anthropic MCP Service
+
+This repository also includes a small HTTP service that exposes the `roll`
+function for use with Anthropic's MCP tools. Start the service and send it a
+request as follows:
+
+```bash
+python -m genia.services.dice_service &
+curl -X POST -d '{"count": 2, "sides": 6}' http://localhost:8000
+```
+
+
 ## Development
 
 To run tests:

--- a/genia/interpreter.py
+++ b/genia/interpreter.py
@@ -434,11 +434,6 @@ class Interpreter:
         self.register_foreign_function("randrange", randrange, parameters=["start", "stop"])
         self.register_foreign_function("randrange", randrange, parameters=["start", "stop", "step"])
 
-        # Define native randint in terms of randrange
-        lexer = Lexer("define randint(a, b) -> randrange(a, b + 1)")
-        parser = Parser(lexer.tokenize())
-        for stmt in parser.parse():
-            self.evaluate(stmt)
         for i in range(1, 8):
             params = [f"msg{j}" for j in range(1, i + 1)]
             self.register_foreign_function("print", self.write_to_stdout, parameters=params)

--- a/genia/services/dice_service.py
+++ b/genia/services/dice_service.py
@@ -1,0 +1,44 @@
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+from genia.interpreter import GENIAInterpreter
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / 'scripts' / 'dice.genia'
+BASE_CODE = SCRIPT_PATH.read_text()
+
+def roll(count: int, sides: int) -> int:
+    """Roll `count` dice each with `sides` sides and return the sum."""
+    interp = GENIAInterpreter()
+    return interp.run(BASE_CODE, args=[str(count), str(sides)])
+
+
+class DiceRequestHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode('utf-8')
+        try:
+            data = json.loads(body)
+            count = int(data.get('count', 1))
+            sides = int(data.get('sides', 6))
+            result = roll(count, sides)
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'result': result}).encode('utf-8'))
+        except Exception as exc:
+            self.send_response(500)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'error': str(exc)}).encode('utf-8'))
+
+
+def serve(host: str = '127.0.0.1', port: int = 8000):
+    """Start a simple HTTP server for rolling dice."""
+    server = HTTPServer((host, port), DiceRequestHandler)
+    print(f"Serving dice roll service on http://{host}:{port}")
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    serve()

--- a/scripts/dice.genia
+++ b/scripts/dice.genia
@@ -1,3 +1,5 @@
+define randint(a, b) -> randrange(a, b + 1)
+
 define roll(sides) -> roll(1, sides)
 define roll(0, _) -> 0
 define roll(n, sides) -> randint(1, sides) + roll(n - 1, sides)

--- a/scripts/dice.genia
+++ b/scripts/dice.genia
@@ -5,7 +5,21 @@ define roll(0, _) -> 0
 define roll(n, sides) -> randint(1, sides) + roll(n - 1, sides)
 
 define int(s) -> foreign "builtins.int"
+define json_loads(s) -> foreign "json.loads"
+define json_dumps(o) -> foreign "json.dumps"
+define dict(pairs) -> foreign "builtins.dict"
+define getitem(obj, key) -> foreign "operator.getitem"
+define dict_get(obj, key, default) -> foreign "genia.services.dice_service.dict_get"
 
-[count, sides] = $ARGS
-print(roll(int(count), int(sides)))
+define handle_request(body) -> (
+    data = json_loads(body);
+    count = int(dict_get(data, "count", 1));
+    sides = int(dict_get(data, "sides", 6));
+    json_dumps(dict([["result", roll(count, sides)]]))
+)
+
+define main([count, sides]) -> print(roll(int(count), int(sides)))
+    | (_) -> 0
+
+main($ARGS)
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,5 +1,14 @@
 import random
+from pathlib import Path
 from genia.interpreter import GENIAInterpreter
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / 'scripts' / 'dice.genia'
+FILE_CONTENT = SCRIPT_PATH.read_text()
+BASE_FUNCTIONS = FILE_CONTENT.split('[count, sides]')[0]
+
+def run(code: str):
+    interp = GENIAInterpreter()
+    return interp.run(BASE_FUNCTIONS + '\n' + code)
 
 
 def test_randrange_foreign_function():
@@ -12,21 +21,13 @@ def test_randrange_foreign_function():
 
 def test_randint_native_function():
     random.seed(0)
-    interp = GENIAInterpreter()
-    result = interp.run("randint(1, 6)")
+    result = run("randint(1, 6)")
     assert result == 4
 
 
 def test_roll_function():
     random.seed(0)
-    code = """
-define roll(sides) -> roll(1, sides)
-define roll(0, _) -> 0
-define roll(n, sides) -> randint(1, sides) + roll(n - 1, sides)
-roll(2, 6)
-"""
-    interp = GENIAInterpreter()
-    result = interp.run(code)
+    result = run("roll(2, 6)")
     assert result == 8
 
 

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -4,11 +4,10 @@ from genia.interpreter import GENIAInterpreter
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / 'scripts' / 'dice.genia'
 FILE_CONTENT = SCRIPT_PATH.read_text()
-BASE_FUNCTIONS = FILE_CONTENT.split('[count, sides]')[0]
 
 def run(code: str):
     interp = GENIAInterpreter()
-    return interp.run(BASE_FUNCTIONS + '\n' + code)
+    return interp.run(FILE_CONTENT + '\n' + code, args=[])
 
 
 def test_randrange_foreign_function():


### PR DESCRIPTION
## Summary
- remove `randint` definition from `GENIAInterpreter`
- define `randint` inside `scripts/dice.genia`
- adjust random tests to load definitions from `dice.genia`
- add simple HTTP service exposing dice rolls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687810c42f148329b1b30369542214c9