### PR TITLE
Add variadic operator functions

### DIFF
--- a/genia/interpreter.py
+++ b/genia/interpreter.py
@@ -20,6 +20,43 @@ from genia.hosted.os import files_in_paths
 from genia.hosted.random_utils import randrange
 import importlib
 
+
+def op_add(*args):
+    """Addition with variable arguments. +() == 0"""
+    return sum(args) if args else 0
+
+
+def op_mul(*args):
+    """Multiplication with variable arguments. *() == 1"""
+    result = 1
+    for a in args:
+        result *= a
+    return result
+
+
+def op_sub(*args):
+    """Subtraction with variable arguments following Clojure semantics."""
+    if not args:
+        return 0
+    if len(args) == 1:
+        return -args[0]
+    result = args[0]
+    for a in args[1:]:
+        result -= a
+    return result
+
+
+def op_div(*args):
+    """Integer division with variable arguments. /() == 1"""
+    if not args:
+        return 1
+    if len(args) == 1:
+        return 1 // args[0]
+    result = args[0]
+    for a in args[1:]:
+        result //= a
+    return result
+
 def bind_list_pattern(pattern, arg, local_env):
     elements = pattern['elements']
     if len(elements) == 0:
@@ -440,6 +477,18 @@ class Interpreter:
         self.register_foreign_function("printenv", self.printenv)
         self.register_foreign_function("printenv", self.printenv, parameters=["name"])
         self.register_foreign_function("trace", self.do_trace)
+
+        # Register operator functions for variable argument support
+        op_funcs = {
+            '+': op_add,
+            '*': op_mul,
+            '-': op_sub,
+            '/': op_div,
+        }
+        for name, func in op_funcs.items():
+            for i in range(0, 9):
+                params = [f"a{j}" for j in range(1, i + 1)]
+                self.register_foreign_function(name, func, parameters=params)
 
     def register_foreign_function(self, name, function, parameters=None, guard=None, line=0, column=0):
         """

--- a/genia/parser.py
+++ b/genia/parser.py
@@ -533,9 +533,25 @@ class Parser:
         if token_type == 'NUMBER':
             return {'type': 'number', 'value': value, 'line': line, 'column': column}
         elif token_type == 'OPERATOR' and value in {'-', '+'}:
-            # Parse the operand of unary '+' and '-' with a higher precedence so
-            # that expressions like `-1..10` are parsed as `( -1 ) .. 10` rather
-            # than `-(1 .. 10)`.
+            # If followed by '(', treat as a function call (e.g., +(1,2))
+            if self.tokens and self.tokens[0][0] == 'PUNCTUATION' and self.tokens[0][1] == '(': 
+                self.tokens.popleft()
+                arguments = []
+                while self.tokens and not (self.tokens[0][0] == 'PUNCTUATION' and self.tokens[0][1] == ')'):
+                    arguments.append(self.expression())
+                    if self.tokens and self.tokens[0][0] == 'PUNCTUATION' and self.tokens[0][1] == ',':
+                        self.tokens.popleft()
+                if not self.tokens or not (self.tokens[0][0] == 'PUNCTUATION' and self.tokens[0][1] == ')'):
+                    raise self.SyntaxError(f"Unmatched '(' in function call at line {line}, column {column}.")
+                self.tokens.popleft()
+                return {
+                    'type': 'function_call',
+                    'name': value,
+                    'arguments': arguments,
+                    'line': line,
+                    'column': column
+                }
+            # Otherwise treat as unary operator
             operand = self.expression(self.PRECEDENCE['UNARY'])
             return {
                     'type': 'unary_operator',
@@ -555,9 +571,9 @@ class Parser:
                     'column': column}
         elif token_type in {'STRING', 'RAW_STRING'}:
             return {'type': token_type.lower(), 'value': value, 'line': line, 'column': column}
-        elif token_type == 'IDENTIFIER':
-            # Check if this is a function call
-            if self.tokens and self.tokens[0][0] == 'PUNCTUATION' and self.tokens[0][1] == '(':
+        elif token_type in {'IDENTIFIER', 'OPERATOR'}:
+            # Check if this is a function call, allowing operators like '+' as names
+            if self.tokens and self.tokens[0][0] == 'PUNCTUATION' and self.tokens[0][1] == '(': 
                 self.tokens.popleft()  # Consume '('
                 arguments = []
                 # Parse arguments separated by commas

--- a/scripts/dice.genia
+++ b/scripts/dice.genia
@@ -23,6 +23,8 @@ define map(func, list) -> reduce(define (acc, el) -> [..acc, func(el)], [], list
 define Roll = Roll(sides, outcome)
 
 define roll(sides) -> define (_) -> Roll(sides, randint(1, sides))
+define roll(0, _) -> 0
+define roll(n, sides) -> randint(1, sides) + roll(n - 1, sides)
 
 define rolls(n, sides) -> map(roll(sides), 1..n)
 define rolls(0, _) -> [Roll(0, 0)]
@@ -53,13 +55,19 @@ define main
     | ([sides]) -> rolls(1, int(sides))
     | (_) -> rolls(1, 20)
 
-rolled = main($ARGS)
+# Only execute when arguments are provided
+define __run_main(args) when args != [] -> (
+    rolled = main(args);
+    print(rolled);
+    print("total");
+    print(sum_rolls(rolled));
+    print("min");
+    print(min_rolls(rolled));
+    print("max");
+    print(max_rolls(rolled))
+)
 
-print(rolled)
-print("total")
-print(sum_rolls(rolled))
-print("min")
-print(min_rolls(rolled))
-print("max")
-print(max_rolls(rolled))
+define __run_main(_) -> 0
+
+__run_main($ARGS)
 

--- a/tests/test_operator_functions.py
+++ b/tests/test_operator_functions.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from genia.interpreter import GENIAInterpreter
+
+
+def run(code: str):
+    interp = GENIAInterpreter()
+    return interp.run(code)
+
+
+def test_add_operator_as_function():
+    assert run("+(1,2,3,4)") == 10
+
+
+def test_mul_operator_no_args():
+    assert run("*()") == 1

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,5 +1,9 @@
 import random
 from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from genia.interpreter import GENIAInterpreter
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / 'scripts' / 'dice.genia'


### PR DESCRIPTION
## Summary
- allow `+`, `-`, `*`, and `/` to be called like regular functions
- add parser support for operator function calls
- extend dice example with recursive `roll` and gated main
- add tests for operator functions
- fix random test imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a844e01e88329bf605408d0f654d7