### PR TITLE
Enable operator functions as first-class values

### DIFF
--- a/tests/test_operator_functions.py
+++ b/tests/test_operator_functions.py
@@ -17,3 +17,13 @@ def test_add_operator_as_function():
 
 def test_mul_operator_no_args():
     assert run("*()") == 1
+
+
+def test_operator_as_argument():
+    code = """
+    define compose(f,g) -> define(a,b) -> f(g(a,b))
+    define double(x) -> x * x
+    f = compose(double, +)
+    f(2,3)
+    """
+    assert run(code) == 25


### PR DESCRIPTION
## Summary
- allow `+` and `-` tokens to be parsed as identifiers when used without an operand
- add regression test showing `compose(double, +)` works

## Testing
- `pytest tests/test_operator_functions.py::test_operator_as_argument -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ac49525948329b8e5458145207d01