### PR TITLE
refactor: centralize list pattern binding

### DIFF
--- a/genia/callable_function.py
+++ b/genia/callable_function.py
@@ -1,6 +1,7 @@
 from genia.lazy_seq import LazySeq
 from collections import deque
 from itertools import islice
+from genia.patterns import bind_list_pattern
 
 
 class CallableFunction:
@@ -72,7 +73,7 @@ class CallableFunction:
         for param, arg in zip(definition['parameters'], args):
             match param.get('type'):
                 case 'list_pattern':
-                    self.bind_list_pattern(param, arg, local_env)
+                    bind_list_pattern(param, arg, local_env)
                 case 'identifier':
                     local_env[param['value']] = arg
                 case 'string':
@@ -82,23 +83,6 @@ class CallableFunction:
                 case _:
                     raise ValueError(f"Unsupported parameter type: {param['type']}")
         return local_env
-
-    def bind_list_pattern(self, pattern, arg, local_env):
-        elements = pattern['elements']
-        if len(elements) == 0:  # Empty list
-            return
-        for i, element in enumerate(elements):
-            if element['type'] == 'rest':
-                # Convert the remaining elements of the iterator into a list
-                if hasattr(arg, '__getitem__'):  # Check if `arg` is a list-like object
-                    local_env[element['value']] = arg[i:]
-                else:  # Assume `arg` is an iterator
-                    local_env[element['value']] = list(islice(arg, i, None))
-            else:
-                if hasattr(arg, '__getitem__'):  # Check if `arg` is a list-like object
-                    local_env[element['value']] = arg[i]
-                else:  # Assume `arg` is an iterator
-                    local_env[element['value']] = next(islice(arg, i, i + 1))
     
     def __repr__(self):
         import json

--- a/genia/patterns.py
+++ b/genia/patterns.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from itertools import islice
+from genia.lazy_seq import LazySeq
+from genia.seq import Sequence, nth_seq
+
+
+def _is_spread(element: dict) -> bool:
+    return (
+        (element.get("type") == "unary_operator" and element.get("operator") == "..")
+        or element.get("type") == "rest"
+    )
+
+
+def _spread_name(element: dict) -> str:
+    if element.get("type") == "unary_operator":
+        return element["operand"]["value"]
+    return element["value"]
+
+
+def bind_list_pattern(pattern: dict, arg, local_env: dict) -> None:
+    """Bind a list pattern to ``arg`` updating ``local_env``.
+
+    Supports patterns like ``[head, ..tail]`` and ``[..pre, mid, ..post]``.
+    ``arg`` may be a list, ``LazySeq`` or ``Sequence`` instance.
+    """
+    elements = pattern["elements"]
+    if len(elements) == 0:
+        return
+
+    # Handle pattern of form [..pre, mid, ..post]
+    if (
+        len(elements) == 3
+        and _is_spread(elements[0])
+        and _is_spread(elements[2])
+        and isinstance(arg, list)
+    ):
+        pre_name = _spread_name(elements[0])
+        post_name = _spread_name(elements[2])
+        mid_pat = elements[1]
+        from genia.interpreter import CallableFunction
+
+        cf = CallableFunction("_bind_helper")
+        for i, val in enumerate(arg):
+            if cf.match_parameter(mid_pat, val):
+                local_env[pre_name] = arg[:i]
+                local_env[post_name] = arg[i + 1 :]
+                match mid_pat.get("type"):
+                    case "identifier":
+                        local_env[mid_pat["value"]] = val
+                    case "wildcard":
+                        pass
+                    case "list_pattern":
+                        bind_list_pattern(mid_pat, val, local_env)
+                    case "constructor_pattern":
+                        cf.bind_constructor_pattern(mid_pat, val, local_env)
+                    case "number_literal":
+                        if val != mid_pat["value"]:
+                            raise RuntimeError("Pattern mismatch")
+                    case "string_literal":
+                        if val != mid_pat["value"]:
+                            raise RuntimeError("Pattern mismatch")
+                return
+        raise RuntimeError("No matching element for pattern")
+
+    for i, element in enumerate(elements):
+        if _is_spread(element):
+            name = _spread_name(element)
+            if isinstance(arg, list):
+                local_env[name] = arg[i:]
+            elif isinstance(arg, LazySeq):
+                local_env[name] = list(islice(arg, i, None))
+            elif isinstance(arg, Sequence):
+                local_env[name] = arg.rest()
+            else:
+                raise ValueError(
+                    f"Unsupported type for spread binding: {type(arg).__name__}"
+                )
+        else:
+            if isinstance(arg, list):
+                if i < len(arg):
+                    if element["type"] == "wildcard":
+                        pass
+                    elif element["type"] == "list_pattern":
+                        bind_list_pattern(element, arg[i], local_env)
+                    else:
+                        local_env[element["value"]] = arg[i]
+                else:
+                    raise RuntimeError(
+                        f"Not enough elements to bind parameter '{element.get('value', '?')}'"
+                    )
+            elif isinstance(arg, LazySeq):
+                try:
+                    v = next(islice(arg, i, i + 1))
+                    if element["type"] == "wildcard":
+                        pass
+                    elif element["type"] == "list_pattern":
+                        bind_list_pattern(element, v, local_env)
+                    else:
+                        local_env[element["value"]] = v
+                except StopIteration:
+                    raise RuntimeError(
+                        f"Not enough elements to bind parameter '{element.get('value', '?')}'"
+                    )
+            elif isinstance(arg, Sequence):
+                try:
+                    v = nth_seq(i, arg)
+                    if element["type"] == "wildcard":
+                        pass
+                    elif element["type"] == "list_pattern":
+                        bind_list_pattern(element, v, local_env)
+                    else:
+                        local_env[element["value"]] = v
+                except StopIteration:
+                    raise RuntimeError(
+                        f"Not enough elements to bind parameter '{element.get('value', '?')}'"
+                    )
+            else:
+                raise ValueError(
+                    f"Unsupported type for binding: {type(arg).__name__}"
+                )

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from genia.patterns import bind_list_pattern
+
+
+def test_bind_head_tail():
+    pattern = {
+        'type': 'list_pattern',
+        'elements': [
+            {'type': 'identifier', 'value': 'head'},
+            {
+                'type': 'unary_operator',
+                'operator': '..',
+                'operand': {'type': 'identifier', 'value': 'tail'}
+            }
+        ]
+    }
+    env = {}
+    bind_list_pattern(pattern, [1, 2, 3], env)
+    assert env == {'head': 1, 'tail': [2, 3]}
+
+
+def test_bind_pre_mid_post():
+    pattern = {
+        'type': 'list_pattern',
+        'elements': [
+            {
+                'type': 'unary_operator',
+                'operator': '..',
+                'operand': {'type': 'identifier', 'value': 'pre'}
+            },
+            {'type': 'identifier', 'value': 'mid'},
+            {
+                'type': 'unary_operator',
+                'operator': '..',
+                'operand': {'type': 'identifier', 'value': 'post'}
+            }
+        ]
+    }
+    env = {}
+    bind_list_pattern(pattern, [1, 2, 3], env)
+    assert env == {'pre': [], 'mid': 1, 'post': [2, 3]}


### PR DESCRIPTION
## Summary
- add `genia.patterns.bind_list_pattern` utility for list pattern binding
- use shared binding in interpreter and CallableFunction
- cover head/tail and pre/mid/post cases with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68950958baa48329a3c4d5782e5d5cd3